### PR TITLE
Add AWS config templates for instances 41-50

### DIFF
--- a/deployment/aws/instance-41/config.template.json
+++ b/deployment/aws/instance-41/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S41N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N40",
+          "host": "${INSTANCE41_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S41N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N2",
+          "host": "${INSTANCE41_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S41N3",
+          "host": "${INSTANCE41_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S41N4",
+          "host": "${INSTANCE41_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S41N5",
+          "host": "${INSTANCE41_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S41N6",
+          "host": "${INSTANCE41_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S41N7",
+          "host": "${INSTANCE41_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S41N8",
+          "host": "${INSTANCE41_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S41N9",
+          "host": "${INSTANCE41_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S41N10",
+          "host": "${INSTANCE41_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S41N11",
+          "host": "${INSTANCE41_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S41N12",
+          "host": "${INSTANCE41_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S41N13",
+          "host": "${INSTANCE41_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S41N14",
+          "host": "${INSTANCE41_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S41N15",
+          "host": "${INSTANCE41_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S41N16",
+          "host": "${INSTANCE41_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S41N17",
+          "host": "${INSTANCE41_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S41N18",
+          "host": "${INSTANCE41_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S41N19",
+          "host": "${INSTANCE41_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S41N20",
+          "host": "${INSTANCE41_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S41N21",
+          "host": "${INSTANCE41_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S41N22",
+          "host": "${INSTANCE41_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S41N23",
+          "host": "${INSTANCE41_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S41N24",
+          "host": "${INSTANCE41_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S41N25",
+          "host": "${INSTANCE41_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S41N26",
+          "host": "${INSTANCE41_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S41N27",
+          "host": "${INSTANCE41_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S41N28",
+          "host": "${INSTANCE41_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S41N29",
+          "host": "${INSTANCE41_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S41N30",
+          "host": "${INSTANCE41_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S41N31",
+          "host": "${INSTANCE41_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S41N32",
+          "host": "${INSTANCE41_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S41N33",
+          "host": "${INSTANCE41_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S41N34",
+          "host": "${INSTANCE41_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S41N35",
+          "host": "${INSTANCE41_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S41N36",
+          "host": "${INSTANCE41_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S41N37",
+          "host": "${INSTANCE41_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S41N38",
+          "host": "${INSTANCE41_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S41N39",
+          "host": "${INSTANCE41_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U41",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE41_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-42/config.template.json
+++ b/deployment/aws/instance-42/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S42N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N40",
+          "host": "${INSTANCE42_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S42N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N2",
+          "host": "${INSTANCE42_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S42N3",
+          "host": "${INSTANCE42_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S42N4",
+          "host": "${INSTANCE42_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S42N5",
+          "host": "${INSTANCE42_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S42N6",
+          "host": "${INSTANCE42_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S42N7",
+          "host": "${INSTANCE42_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S42N8",
+          "host": "${INSTANCE42_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S42N9",
+          "host": "${INSTANCE42_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S42N10",
+          "host": "${INSTANCE42_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S42N11",
+          "host": "${INSTANCE42_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S42N12",
+          "host": "${INSTANCE42_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S42N13",
+          "host": "${INSTANCE42_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S42N14",
+          "host": "${INSTANCE42_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S42N15",
+          "host": "${INSTANCE42_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S42N16",
+          "host": "${INSTANCE42_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S42N17",
+          "host": "${INSTANCE42_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S42N18",
+          "host": "${INSTANCE42_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S42N19",
+          "host": "${INSTANCE42_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S42N20",
+          "host": "${INSTANCE42_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S42N21",
+          "host": "${INSTANCE42_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S42N22",
+          "host": "${INSTANCE42_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S42N23",
+          "host": "${INSTANCE42_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S42N24",
+          "host": "${INSTANCE42_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S42N25",
+          "host": "${INSTANCE42_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S42N26",
+          "host": "${INSTANCE42_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S42N27",
+          "host": "${INSTANCE42_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S42N28",
+          "host": "${INSTANCE42_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S42N29",
+          "host": "${INSTANCE42_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S42N30",
+          "host": "${INSTANCE42_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S42N31",
+          "host": "${INSTANCE42_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S42N32",
+          "host": "${INSTANCE42_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S42N33",
+          "host": "${INSTANCE42_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S42N34",
+          "host": "${INSTANCE42_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S42N35",
+          "host": "${INSTANCE42_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S42N36",
+          "host": "${INSTANCE42_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S42N37",
+          "host": "${INSTANCE42_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S42N38",
+          "host": "${INSTANCE42_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S42N39",
+          "host": "${INSTANCE42_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U42",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE42_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-43/config.template.json
+++ b/deployment/aws/instance-43/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S43N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N40",
+          "host": "${INSTANCE43_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S43N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N2",
+          "host": "${INSTANCE43_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S43N3",
+          "host": "${INSTANCE43_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S43N4",
+          "host": "${INSTANCE43_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S43N5",
+          "host": "${INSTANCE43_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S43N6",
+          "host": "${INSTANCE43_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S43N7",
+          "host": "${INSTANCE43_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S43N8",
+          "host": "${INSTANCE43_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S43N9",
+          "host": "${INSTANCE43_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S43N10",
+          "host": "${INSTANCE43_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S43N11",
+          "host": "${INSTANCE43_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S43N12",
+          "host": "${INSTANCE43_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S43N13",
+          "host": "${INSTANCE43_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S43N14",
+          "host": "${INSTANCE43_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S43N15",
+          "host": "${INSTANCE43_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S43N16",
+          "host": "${INSTANCE43_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S43N17",
+          "host": "${INSTANCE43_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S43N18",
+          "host": "${INSTANCE43_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S43N19",
+          "host": "${INSTANCE43_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S43N20",
+          "host": "${INSTANCE43_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S43N21",
+          "host": "${INSTANCE43_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S43N22",
+          "host": "${INSTANCE43_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S43N23",
+          "host": "${INSTANCE43_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S43N24",
+          "host": "${INSTANCE43_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S43N25",
+          "host": "${INSTANCE43_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S43N26",
+          "host": "${INSTANCE43_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S43N27",
+          "host": "${INSTANCE43_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S43N28",
+          "host": "${INSTANCE43_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S43N29",
+          "host": "${INSTANCE43_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S43N30",
+          "host": "${INSTANCE43_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S43N31",
+          "host": "${INSTANCE43_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S43N32",
+          "host": "${INSTANCE43_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S43N33",
+          "host": "${INSTANCE43_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S43N34",
+          "host": "${INSTANCE43_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S43N35",
+          "host": "${INSTANCE43_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S43N36",
+          "host": "${INSTANCE43_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S43N37",
+          "host": "${INSTANCE43_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S43N38",
+          "host": "${INSTANCE43_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S43N39",
+          "host": "${INSTANCE43_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U43",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE43_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-44/config.template.json
+++ b/deployment/aws/instance-44/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S44N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N40",
+          "host": "${INSTANCE44_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S44N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N2",
+          "host": "${INSTANCE44_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S44N3",
+          "host": "${INSTANCE44_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S44N4",
+          "host": "${INSTANCE44_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S44N5",
+          "host": "${INSTANCE44_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S44N6",
+          "host": "${INSTANCE44_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S44N7",
+          "host": "${INSTANCE44_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S44N8",
+          "host": "${INSTANCE44_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S44N9",
+          "host": "${INSTANCE44_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S44N10",
+          "host": "${INSTANCE44_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S44N11",
+          "host": "${INSTANCE44_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S44N12",
+          "host": "${INSTANCE44_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S44N13",
+          "host": "${INSTANCE44_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S44N14",
+          "host": "${INSTANCE44_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S44N15",
+          "host": "${INSTANCE44_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S44N16",
+          "host": "${INSTANCE44_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S44N17",
+          "host": "${INSTANCE44_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S44N18",
+          "host": "${INSTANCE44_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S44N19",
+          "host": "${INSTANCE44_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S44N20",
+          "host": "${INSTANCE44_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S44N21",
+          "host": "${INSTANCE44_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S44N22",
+          "host": "${INSTANCE44_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S44N23",
+          "host": "${INSTANCE44_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S44N24",
+          "host": "${INSTANCE44_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S44N25",
+          "host": "${INSTANCE44_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S44N26",
+          "host": "${INSTANCE44_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S44N27",
+          "host": "${INSTANCE44_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S44N28",
+          "host": "${INSTANCE44_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S44N29",
+          "host": "${INSTANCE44_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S44N30",
+          "host": "${INSTANCE44_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S44N31",
+          "host": "${INSTANCE44_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S44N32",
+          "host": "${INSTANCE44_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S44N33",
+          "host": "${INSTANCE44_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S44N34",
+          "host": "${INSTANCE44_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S44N35",
+          "host": "${INSTANCE44_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S44N36",
+          "host": "${INSTANCE44_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S44N37",
+          "host": "${INSTANCE44_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S44N38",
+          "host": "${INSTANCE44_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S44N39",
+          "host": "${INSTANCE44_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U44",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE44_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-45/config.template.json
+++ b/deployment/aws/instance-45/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S45N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N40",
+          "host": "${INSTANCE45_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S45N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N2",
+          "host": "${INSTANCE45_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S45N3",
+          "host": "${INSTANCE45_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S45N4",
+          "host": "${INSTANCE45_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S45N5",
+          "host": "${INSTANCE45_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S45N6",
+          "host": "${INSTANCE45_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S45N7",
+          "host": "${INSTANCE45_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S45N8",
+          "host": "${INSTANCE45_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S45N9",
+          "host": "${INSTANCE45_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S45N10",
+          "host": "${INSTANCE45_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S45N11",
+          "host": "${INSTANCE45_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S45N12",
+          "host": "${INSTANCE45_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S45N13",
+          "host": "${INSTANCE45_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S45N14",
+          "host": "${INSTANCE45_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S45N15",
+          "host": "${INSTANCE45_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S45N16",
+          "host": "${INSTANCE45_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S45N17",
+          "host": "${INSTANCE45_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S45N18",
+          "host": "${INSTANCE45_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S45N19",
+          "host": "${INSTANCE45_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S45N20",
+          "host": "${INSTANCE45_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S45N21",
+          "host": "${INSTANCE45_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S45N22",
+          "host": "${INSTANCE45_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S45N23",
+          "host": "${INSTANCE45_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S45N24",
+          "host": "${INSTANCE45_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S45N25",
+          "host": "${INSTANCE45_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S45N26",
+          "host": "${INSTANCE45_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S45N27",
+          "host": "${INSTANCE45_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S45N28",
+          "host": "${INSTANCE45_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S45N29",
+          "host": "${INSTANCE45_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S45N30",
+          "host": "${INSTANCE45_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S45N31",
+          "host": "${INSTANCE45_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S45N32",
+          "host": "${INSTANCE45_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S45N33",
+          "host": "${INSTANCE45_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S45N34",
+          "host": "${INSTANCE45_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S45N35",
+          "host": "${INSTANCE45_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S45N36",
+          "host": "${INSTANCE45_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S45N37",
+          "host": "${INSTANCE45_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S45N38",
+          "host": "${INSTANCE45_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S45N39",
+          "host": "${INSTANCE45_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U45",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE45_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-46/config.template.json
+++ b/deployment/aws/instance-46/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S46N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N40",
+          "host": "${INSTANCE46_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S46N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N2",
+          "host": "${INSTANCE46_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S46N3",
+          "host": "${INSTANCE46_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S46N4",
+          "host": "${INSTANCE46_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S46N5",
+          "host": "${INSTANCE46_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S46N6",
+          "host": "${INSTANCE46_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S46N7",
+          "host": "${INSTANCE46_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S46N8",
+          "host": "${INSTANCE46_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S46N9",
+          "host": "${INSTANCE46_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S46N10",
+          "host": "${INSTANCE46_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S46N11",
+          "host": "${INSTANCE46_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S46N12",
+          "host": "${INSTANCE46_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S46N13",
+          "host": "${INSTANCE46_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S46N14",
+          "host": "${INSTANCE46_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S46N15",
+          "host": "${INSTANCE46_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S46N16",
+          "host": "${INSTANCE46_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S46N17",
+          "host": "${INSTANCE46_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S46N18",
+          "host": "${INSTANCE46_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S46N19",
+          "host": "${INSTANCE46_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S46N20",
+          "host": "${INSTANCE46_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S46N21",
+          "host": "${INSTANCE46_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S46N22",
+          "host": "${INSTANCE46_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S46N23",
+          "host": "${INSTANCE46_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S46N24",
+          "host": "${INSTANCE46_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S46N25",
+          "host": "${INSTANCE46_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S46N26",
+          "host": "${INSTANCE46_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S46N27",
+          "host": "${INSTANCE46_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S46N28",
+          "host": "${INSTANCE46_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S46N29",
+          "host": "${INSTANCE46_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S46N30",
+          "host": "${INSTANCE46_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S46N31",
+          "host": "${INSTANCE46_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S46N32",
+          "host": "${INSTANCE46_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S46N33",
+          "host": "${INSTANCE46_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S46N34",
+          "host": "${INSTANCE46_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S46N35",
+          "host": "${INSTANCE46_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S46N36",
+          "host": "${INSTANCE46_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S46N37",
+          "host": "${INSTANCE46_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S46N38",
+          "host": "${INSTANCE46_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S46N39",
+          "host": "${INSTANCE46_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U46",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE46_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-47/config.template.json
+++ b/deployment/aws/instance-47/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S47N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N40",
+          "host": "${INSTANCE47_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S47N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N2",
+          "host": "${INSTANCE47_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S47N3",
+          "host": "${INSTANCE47_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S47N4",
+          "host": "${INSTANCE47_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S47N5",
+          "host": "${INSTANCE47_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S47N6",
+          "host": "${INSTANCE47_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S47N7",
+          "host": "${INSTANCE47_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S47N8",
+          "host": "${INSTANCE47_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S47N9",
+          "host": "${INSTANCE47_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S47N10",
+          "host": "${INSTANCE47_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S47N11",
+          "host": "${INSTANCE47_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S47N12",
+          "host": "${INSTANCE47_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S47N13",
+          "host": "${INSTANCE47_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S47N14",
+          "host": "${INSTANCE47_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S47N15",
+          "host": "${INSTANCE47_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S47N16",
+          "host": "${INSTANCE47_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S47N17",
+          "host": "${INSTANCE47_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S47N18",
+          "host": "${INSTANCE47_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S47N19",
+          "host": "${INSTANCE47_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S47N20",
+          "host": "${INSTANCE47_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S47N21",
+          "host": "${INSTANCE47_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S47N22",
+          "host": "${INSTANCE47_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S47N23",
+          "host": "${INSTANCE47_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S47N24",
+          "host": "${INSTANCE47_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S47N25",
+          "host": "${INSTANCE47_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S47N26",
+          "host": "${INSTANCE47_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S47N27",
+          "host": "${INSTANCE47_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S47N28",
+          "host": "${INSTANCE47_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S47N29",
+          "host": "${INSTANCE47_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S47N30",
+          "host": "${INSTANCE47_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S47N31",
+          "host": "${INSTANCE47_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S47N32",
+          "host": "${INSTANCE47_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S47N33",
+          "host": "${INSTANCE47_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S47N34",
+          "host": "${INSTANCE47_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S47N35",
+          "host": "${INSTANCE47_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S47N36",
+          "host": "${INSTANCE47_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S47N37",
+          "host": "${INSTANCE47_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S47N38",
+          "host": "${INSTANCE47_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S47N39",
+          "host": "${INSTANCE47_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U47",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE47_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-48/config.template.json
+++ b/deployment/aws/instance-48/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S48N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N40",
+          "host": "${INSTANCE48_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S48N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N2",
+          "host": "${INSTANCE48_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S48N3",
+          "host": "${INSTANCE48_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S48N4",
+          "host": "${INSTANCE48_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S48N5",
+          "host": "${INSTANCE48_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S48N6",
+          "host": "${INSTANCE48_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S48N7",
+          "host": "${INSTANCE48_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S48N8",
+          "host": "${INSTANCE48_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S48N9",
+          "host": "${INSTANCE48_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S48N10",
+          "host": "${INSTANCE48_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S48N11",
+          "host": "${INSTANCE48_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S48N12",
+          "host": "${INSTANCE48_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S48N13",
+          "host": "${INSTANCE48_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S48N14",
+          "host": "${INSTANCE48_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S48N15",
+          "host": "${INSTANCE48_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S48N16",
+          "host": "${INSTANCE48_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S48N17",
+          "host": "${INSTANCE48_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S48N18",
+          "host": "${INSTANCE48_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S48N19",
+          "host": "${INSTANCE48_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S48N20",
+          "host": "${INSTANCE48_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S48N21",
+          "host": "${INSTANCE48_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S48N22",
+          "host": "${INSTANCE48_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S48N23",
+          "host": "${INSTANCE48_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S48N24",
+          "host": "${INSTANCE48_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S48N25",
+          "host": "${INSTANCE48_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S48N26",
+          "host": "${INSTANCE48_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S48N27",
+          "host": "${INSTANCE48_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S48N28",
+          "host": "${INSTANCE48_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S48N29",
+          "host": "${INSTANCE48_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S48N30",
+          "host": "${INSTANCE48_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S48N31",
+          "host": "${INSTANCE48_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S48N32",
+          "host": "${INSTANCE48_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S48N33",
+          "host": "${INSTANCE48_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S48N34",
+          "host": "${INSTANCE48_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S48N35",
+          "host": "${INSTANCE48_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S48N36",
+          "host": "${INSTANCE48_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S48N37",
+          "host": "${INSTANCE48_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S48N38",
+          "host": "${INSTANCE48_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S48N39",
+          "host": "${INSTANCE48_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U48",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE48_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-49/config.template.json
+++ b/deployment/aws/instance-49/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S49N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N40",
+          "host": "${INSTANCE49_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S49N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N2",
+          "host": "${INSTANCE49_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S49N3",
+          "host": "${INSTANCE49_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S49N4",
+          "host": "${INSTANCE49_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S49N5",
+          "host": "${INSTANCE49_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S49N6",
+          "host": "${INSTANCE49_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S49N7",
+          "host": "${INSTANCE49_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S49N8",
+          "host": "${INSTANCE49_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S49N9",
+          "host": "${INSTANCE49_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S49N10",
+          "host": "${INSTANCE49_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S49N11",
+          "host": "${INSTANCE49_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S49N12",
+          "host": "${INSTANCE49_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S49N13",
+          "host": "${INSTANCE49_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S49N14",
+          "host": "${INSTANCE49_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S49N15",
+          "host": "${INSTANCE49_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S49N16",
+          "host": "${INSTANCE49_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S49N17",
+          "host": "${INSTANCE49_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S49N18",
+          "host": "${INSTANCE49_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S49N19",
+          "host": "${INSTANCE49_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S49N20",
+          "host": "${INSTANCE49_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S49N21",
+          "host": "${INSTANCE49_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S49N22",
+          "host": "${INSTANCE49_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S49N23",
+          "host": "${INSTANCE49_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S49N24",
+          "host": "${INSTANCE49_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S49N25",
+          "host": "${INSTANCE49_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S49N26",
+          "host": "${INSTANCE49_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S49N27",
+          "host": "${INSTANCE49_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S49N28",
+          "host": "${INSTANCE49_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S49N29",
+          "host": "${INSTANCE49_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S49N30",
+          "host": "${INSTANCE49_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S49N31",
+          "host": "${INSTANCE49_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S49N32",
+          "host": "${INSTANCE49_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S49N33",
+          "host": "${INSTANCE49_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S49N34",
+          "host": "${INSTANCE49_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S49N35",
+          "host": "${INSTANCE49_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S49N36",
+          "host": "${INSTANCE49_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S49N37",
+          "host": "${INSTANCE49_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S49N38",
+          "host": "${INSTANCE49_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S49N39",
+          "host": "${INSTANCE49_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U49",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE49_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-50/config.template.json
+++ b/deployment/aws/instance-50/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S50N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N40",
+          "host": "${INSTANCE50_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S50N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N2",
+          "host": "${INSTANCE50_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S50N3",
+          "host": "${INSTANCE50_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S50N4",
+          "host": "${INSTANCE50_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S50N5",
+          "host": "${INSTANCE50_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S50N6",
+          "host": "${INSTANCE50_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S50N7",
+          "host": "${INSTANCE50_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S50N8",
+          "host": "${INSTANCE50_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S50N9",
+          "host": "${INSTANCE50_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S50N10",
+          "host": "${INSTANCE50_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S50N11",
+          "host": "${INSTANCE50_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S50N12",
+          "host": "${INSTANCE50_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S50N13",
+          "host": "${INSTANCE50_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S50N14",
+          "host": "${INSTANCE50_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S50N15",
+          "host": "${INSTANCE50_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S50N16",
+          "host": "${INSTANCE50_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S50N17",
+          "host": "${INSTANCE50_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S50N18",
+          "host": "${INSTANCE50_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S50N19",
+          "host": "${INSTANCE50_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S50N20",
+          "host": "${INSTANCE50_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S50N21",
+          "host": "${INSTANCE50_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S50N22",
+          "host": "${INSTANCE50_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S50N23",
+          "host": "${INSTANCE50_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S50N24",
+          "host": "${INSTANCE50_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S50N25",
+          "host": "${INSTANCE50_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S50N26",
+          "host": "${INSTANCE50_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S50N27",
+          "host": "${INSTANCE50_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S50N28",
+          "host": "${INSTANCE50_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S50N29",
+          "host": "${INSTANCE50_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S50N30",
+          "host": "${INSTANCE50_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S50N31",
+          "host": "${INSTANCE50_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S50N32",
+          "host": "${INSTANCE50_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S50N33",
+          "host": "${INSTANCE50_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S50N34",
+          "host": "${INSTANCE50_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S50N35",
+          "host": "${INSTANCE50_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S50N36",
+          "host": "${INSTANCE50_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S50N37",
+          "host": "${INSTANCE50_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S50N38",
+          "host": "${INSTANCE50_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S50N39",
+          "host": "${INSTANCE50_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U50",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE50_IP}:62000"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add AWS config templates for instances 41-50 mirroring the existing 40-node topology
- include user bootstrap entries for each new instance to match prior configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d90abdbe7c832795302ca555e468d9