### PR TITLE
Reduce AWS instance node count to 20 for first 10 configs

### DIFF
--- a/deployment/aws/instance-1/config.template.json
+++ b/deployment/aws/instance-1/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N40", "host": "${INSTANCE1_IP}", "port": 62039 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S1N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S1N2", "host": "${INSTANCE1_IP}", "port": 62001 },        { "node_id": "S1N3", "host": "${INSTANCE1_IP}", "port": 62002 },        { "node_id": "S1N4", "host": "${INSTANCE1_IP}", "port": 62003 },        { "node_id": "S1N5", "host": "${INSTANCE1_IP}", "port": 62004 },        { "node_id": "S1N6", "host": "${INSTANCE1_IP}", "port": 62005 },        { "node_id": "S1N7", "host": "${INSTANCE1_IP}", "port": 62006 },        { "node_id": "S1N8", "host": "${INSTANCE1_IP}", "port": 62007 },        { "node_id": "S1N9", "host": "${INSTANCE1_IP}", "port": 62008 },        { "node_id": "S1N10", "host": "${INSTANCE1_IP}", "port": 62009 },        { "node_id": "S1N11", "host": "${INSTANCE1_IP}", "port": 62010 },        { "node_id": "S1N12", "host": "${INSTANCE1_IP}", "port": 62011 },        { "node_id": "S1N13", "host": "${INSTANCE1_IP}", "port": 62012 },        { "node_id": "S1N14", "host": "${INSTANCE1_IP}", "port": 62013 },        { "node_id": "S1N15", "host": "${INSTANCE1_IP}", "port": 62014 },        { "node_id": "S1N16", "host": "${INSTANCE1_IP}", "port": 62015 },        { "node_id": "S1N17", "host": "${INSTANCE1_IP}", "port": 62016 },        { "node_id": "S1N18", "host": "${INSTANCE1_IP}", "port": 62017 },        { "node_id": "S1N19", "host": "${INSTANCE1_IP}", "port": 62018 },        { "node_id": "S1N20", "host": "${INSTANCE1_IP}", "port": 62019 },        { "node_id": "S1N21", "host": "${INSTANCE1_IP}", "port": 62020 },        { "node_id": "S1N22", "host": "${INSTANCE1_IP}", "port": 62021 },        { "node_id": "S1N23", "host": "${INSTANCE1_IP}", "port": 62022 },        { "node_id": "S1N24", "host": "${INSTANCE1_IP}", "port": 62023 },        { "node_id": "S1N25", "host": "${INSTANCE1_IP}", "port": 62024 },        { "node_id": "S1N26", "host": "${INSTANCE1_IP}", "port": 62025 },        { "node_id": "S1N27", "host": "${INSTANCE1_IP}", "port": 62026 },        { "node_id": "S1N28", "host": "${INSTANCE1_IP}", "port": 62027 },        { "node_id": "S1N29", "host": "${INSTANCE1_IP}", "port": 62028 },        { "node_id": "S1N30", "host": "${INSTANCE1_IP}", "port": 62029 },        { "node_id": "S1N31", "host": "${INSTANCE1_IP}", "port": 62030 },        { "node_id": "S1N32", "host": "${INSTANCE1_IP}", "port": 62031 },        { "node_id": "S1N33", "host": "${INSTANCE1_IP}", "port": 62032 },        { "node_id": "S1N34", "host": "${INSTANCE1_IP}", "port": 62033 },        { "node_id": "S1N35", "host": "${INSTANCE1_IP}", "port": 62034 },        { "node_id": "S1N36", "host": "${INSTANCE1_IP}", "port": 62035 },        { "node_id": "S1N37", "host": "${INSTANCE1_IP}", "port": 62036 },        { "node_id": "S1N38", "host": "${INSTANCE1_IP}", "port": 62037 },        { "node_id": "S1N39", "host": "${INSTANCE1_IP}", "port": 62038 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-10/config.template.json
+++ b/deployment/aws/instance-10/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N40", "host": "${INSTANCE10_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S10N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S10N2", "host": "${INSTANCE10_IP}", "port": 62001 },        { "node_id": "S10N3", "host": "${INSTANCE10_IP}", "port": 62002 },        { "node_id": "S10N4", "host": "${INSTANCE10_IP}", "port": 62003 },        { "node_id": "S10N5", "host": "${INSTANCE10_IP}", "port": 62004 },        { "node_id": "S10N6", "host": "${INSTANCE10_IP}", "port": 62005 },        { "node_id": "S10N7", "host": "${INSTANCE10_IP}", "port": 62006 },        { "node_id": "S10N8", "host": "${INSTANCE10_IP}", "port": 62007 },        { "node_id": "S10N9", "host": "${INSTANCE10_IP}", "port": 62008 },        { "node_id": "S10N10", "host": "${INSTANCE10_IP}", "port": 62009 },        { "node_id": "S10N11", "host": "${INSTANCE10_IP}", "port": 62010 },        { "node_id": "S10N12", "host": "${INSTANCE10_IP}", "port": 62011 },        { "node_id": "S10N13", "host": "${INSTANCE10_IP}", "port": 62012 },        { "node_id": "S10N14", "host": "${INSTANCE10_IP}", "port": 62013 },        { "node_id": "S10N15", "host": "${INSTANCE10_IP}", "port": 62014 },        { "node_id": "S10N16", "host": "${INSTANCE10_IP}", "port": 62015 },        { "node_id": "S10N17", "host": "${INSTANCE10_IP}", "port": 62016 },        { "node_id": "S10N18", "host": "${INSTANCE10_IP}", "port": 62017 },        { "node_id": "S10N19", "host": "${INSTANCE10_IP}", "port": 62018 },        { "node_id": "S10N20", "host": "${INSTANCE10_IP}", "port": 62019 },        { "node_id": "S10N21", "host": "${INSTANCE10_IP}", "port": 62020 },        { "node_id": "S10N22", "host": "${INSTANCE10_IP}", "port": 62021 },        { "node_id": "S10N23", "host": "${INSTANCE10_IP}", "port": 62022 },        { "node_id": "S10N24", "host": "${INSTANCE10_IP}", "port": 62023 },        { "node_id": "S10N25", "host": "${INSTANCE10_IP}", "port": 62024 },        { "node_id": "S10N26", "host": "${INSTANCE10_IP}", "port": 62025 },        { "node_id": "S10N27", "host": "${INSTANCE10_IP}", "port": 62026 },        { "node_id": "S10N28", "host": "${INSTANCE10_IP}", "port": 62027 },        { "node_id": "S10N29", "host": "${INSTANCE10_IP}", "port": 62028 },        { "node_id": "S10N30", "host": "${INSTANCE10_IP}", "port": 62029 },        { "node_id": "S10N31", "host": "${INSTANCE10_IP}", "port": 62030 },        { "node_id": "S10N32", "host": "${INSTANCE10_IP}", "port": 62031 },        { "node_id": "S10N33", "host": "${INSTANCE10_IP}", "port": 62032 },        { "node_id": "S10N34", "host": "${INSTANCE10_IP}", "port": 62033 },        { "node_id": "S10N35", "host": "${INSTANCE10_IP}", "port": 62034 },        { "node_id": "S10N36", "host": "${INSTANCE10_IP}", "port": 62035 },        { "node_id": "S10N37", "host": "${INSTANCE10_IP}", "port": 62036 },        { "node_id": "S10N38", "host": "${INSTANCE10_IP}", "port": 62037 },        { "node_id": "S10N39", "host": "${INSTANCE10_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-2/config.template.json
+++ b/deployment/aws/instance-2/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N40", "host": "${INSTANCE2_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S2N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S2N2", "host": "${INSTANCE2_IP}", "port": 62001 },        { "node_id": "S2N3", "host": "${INSTANCE2_IP}", "port": 62002 },        { "node_id": "S2N4", "host": "${INSTANCE2_IP}", "port": 62003 },        { "node_id": "S2N5", "host": "${INSTANCE2_IP}", "port": 62004 },        { "node_id": "S2N6", "host": "${INSTANCE2_IP}", "port": 62005 },        { "node_id": "S2N7", "host": "${INSTANCE2_IP}", "port": 62006 },        { "node_id": "S2N8", "host": "${INSTANCE2_IP}", "port": 62007 },        { "node_id": "S2N9", "host": "${INSTANCE2_IP}", "port": 62008 },        { "node_id": "S2N10", "host": "${INSTANCE2_IP}", "port": 62009 },        { "node_id": "S2N11", "host": "${INSTANCE2_IP}", "port": 62010 },        { "node_id": "S2N12", "host": "${INSTANCE2_IP}", "port": 62011 },        { "node_id": "S2N13", "host": "${INSTANCE2_IP}", "port": 62012 },        { "node_id": "S2N14", "host": "${INSTANCE2_IP}", "port": 62013 },        { "node_id": "S2N15", "host": "${INSTANCE2_IP}", "port": 62014 },        { "node_id": "S2N16", "host": "${INSTANCE2_IP}", "port": 62015 },        { "node_id": "S2N17", "host": "${INSTANCE2_IP}", "port": 62016 },        { "node_id": "S2N18", "host": "${INSTANCE2_IP}", "port": 62017 },        { "node_id": "S2N19", "host": "${INSTANCE2_IP}", "port": 62018 },        { "node_id": "S2N20", "host": "${INSTANCE2_IP}", "port": 62019 },        { "node_id": "S2N21", "host": "${INSTANCE2_IP}", "port": 62020 },        { "node_id": "S2N22", "host": "${INSTANCE2_IP}", "port": 62021 },        { "node_id": "S2N23", "host": "${INSTANCE2_IP}", "port": 62022 },        { "node_id": "S2N24", "host": "${INSTANCE2_IP}", "port": 62023 },        { "node_id": "S2N25", "host": "${INSTANCE2_IP}", "port": 62024 },        { "node_id": "S2N26", "host": "${INSTANCE2_IP}", "port": 62025 },        { "node_id": "S2N27", "host": "${INSTANCE2_IP}", "port": 62026 },        { "node_id": "S2N28", "host": "${INSTANCE2_IP}", "port": 62027 },        { "node_id": "S2N29", "host": "${INSTANCE2_IP}", "port": 62028 },        { "node_id": "S2N30", "host": "${INSTANCE2_IP}", "port": 62029 },        { "node_id": "S2N31", "host": "${INSTANCE2_IP}", "port": 62030 },        { "node_id": "S2N32", "host": "${INSTANCE2_IP}", "port": 62031 },        { "node_id": "S2N33", "host": "${INSTANCE2_IP}", "port": 62032 },        { "node_id": "S2N34", "host": "${INSTANCE2_IP}", "port": 62033 },        { "node_id": "S2N35", "host": "${INSTANCE2_IP}", "port": 62034 },        { "node_id": "S2N36", "host": "${INSTANCE2_IP}", "port": 62035 },        { "node_id": "S2N37", "host": "${INSTANCE2_IP}", "port": 62036 },        { "node_id": "S2N38", "host": "${INSTANCE2_IP}", "port": 62037 },        { "node_id": "S2N39", "host": "${INSTANCE2_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-3/config.template.json
+++ b/deployment/aws/instance-3/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N40", "host": "${INSTANCE3_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S3N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S3N2", "host": "${INSTANCE3_IP}", "port": 62001 },        { "node_id": "S3N3", "host": "${INSTANCE3_IP}", "port": 62002 },        { "node_id": "S3N4", "host": "${INSTANCE3_IP}", "port": 62003 },        { "node_id": "S3N5", "host": "${INSTANCE3_IP}", "port": 62004 },        { "node_id": "S3N6", "host": "${INSTANCE3_IP}", "port": 62005 },        { "node_id": "S3N7", "host": "${INSTANCE3_IP}", "port": 62006 },        { "node_id": "S3N8", "host": "${INSTANCE3_IP}", "port": 62007 },        { "node_id": "S3N9", "host": "${INSTANCE3_IP}", "port": 62008 },        { "node_id": "S3N10", "host": "${INSTANCE3_IP}", "port": 62009 },        { "node_id": "S3N11", "host": "${INSTANCE3_IP}", "port": 62010 },        { "node_id": "S3N12", "host": "${INSTANCE3_IP}", "port": 62011 },        { "node_id": "S3N13", "host": "${INSTANCE3_IP}", "port": 62012 },        { "node_id": "S3N14", "host": "${INSTANCE3_IP}", "port": 62013 },        { "node_id": "S3N15", "host": "${INSTANCE3_IP}", "port": 62014 },        { "node_id": "S3N16", "host": "${INSTANCE3_IP}", "port": 62015 },        { "node_id": "S3N17", "host": "${INSTANCE3_IP}", "port": 62016 },        { "node_id": "S3N18", "host": "${INSTANCE3_IP}", "port": 62017 },        { "node_id": "S3N19", "host": "${INSTANCE3_IP}", "port": 62018 },        { "node_id": "S3N20", "host": "${INSTANCE3_IP}", "port": 62019 },        { "node_id": "S3N21", "host": "${INSTANCE3_IP}", "port": 62020 },        { "node_id": "S3N22", "host": "${INSTANCE3_IP}", "port": 62021 },        { "node_id": "S3N23", "host": "${INSTANCE3_IP}", "port": 62022 },        { "node_id": "S3N24", "host": "${INSTANCE3_IP}", "port": 62023 },        { "node_id": "S3N25", "host": "${INSTANCE3_IP}", "port": 62024 },        { "node_id": "S3N26", "host": "${INSTANCE3_IP}", "port": 62025 },        { "node_id": "S3N27", "host": "${INSTANCE3_IP}", "port": 62026 },        { "node_id": "S3N28", "host": "${INSTANCE3_IP}", "port": 62027 },        { "node_id": "S3N29", "host": "${INSTANCE3_IP}", "port": 62028 },        { "node_id": "S3N30", "host": "${INSTANCE3_IP}", "port": 62029 },        { "node_id": "S3N31", "host": "${INSTANCE3_IP}", "port": 62030 },        { "node_id": "S3N32", "host": "${INSTANCE3_IP}", "port": 62031 },        { "node_id": "S3N33", "host": "${INSTANCE3_IP}", "port": 62032 },        { "node_id": "S3N34", "host": "${INSTANCE3_IP}", "port": 62033 },        { "node_id": "S3N35", "host": "${INSTANCE3_IP}", "port": 62034 },        { "node_id": "S3N36", "host": "${INSTANCE3_IP}", "port": 62035 },        { "node_id": "S3N37", "host": "${INSTANCE3_IP}", "port": 62036 },        { "node_id": "S3N38", "host": "${INSTANCE3_IP}", "port": 62037 },        { "node_id": "S3N39", "host": "${INSTANCE3_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-4/config.template.json
+++ b/deployment/aws/instance-4/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N40", "host": "${INSTANCE4_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S4N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S4N2", "host": "${INSTANCE4_IP}", "port": 62001 },        { "node_id": "S4N3", "host": "${INSTANCE4_IP}", "port": 62002 },        { "node_id": "S4N4", "host": "${INSTANCE4_IP}", "port": 62003 },        { "node_id": "S4N5", "host": "${INSTANCE4_IP}", "port": 62004 },        { "node_id": "S4N6", "host": "${INSTANCE4_IP}", "port": 62005 },        { "node_id": "S4N7", "host": "${INSTANCE4_IP}", "port": 62006 },        { "node_id": "S4N8", "host": "${INSTANCE4_IP}", "port": 62007 },        { "node_id": "S4N9", "host": "${INSTANCE4_IP}", "port": 62008 },        { "node_id": "S4N10", "host": "${INSTANCE4_IP}", "port": 62009 },        { "node_id": "S4N11", "host": "${INSTANCE4_IP}", "port": 62010 },        { "node_id": "S4N12", "host": "${INSTANCE4_IP}", "port": 62011 },        { "node_id": "S4N13", "host": "${INSTANCE4_IP}", "port": 62012 },        { "node_id": "S4N14", "host": "${INSTANCE4_IP}", "port": 62013 },        { "node_id": "S4N15", "host": "${INSTANCE4_IP}", "port": 62014 },        { "node_id": "S4N16", "host": "${INSTANCE4_IP}", "port": 62015 },        { "node_id": "S4N17", "host": "${INSTANCE4_IP}", "port": 62016 },        { "node_id": "S4N18", "host": "${INSTANCE4_IP}", "port": 62017 },        { "node_id": "S4N19", "host": "${INSTANCE4_IP}", "port": 62018 },        { "node_id": "S4N20", "host": "${INSTANCE4_IP}", "port": 62019 },        { "node_id": "S4N21", "host": "${INSTANCE4_IP}", "port": 62020 },        { "node_id": "S4N22", "host": "${INSTANCE4_IP}", "port": 62021 },        { "node_id": "S4N23", "host": "${INSTANCE4_IP}", "port": 62022 },        { "node_id": "S4N24", "host": "${INSTANCE4_IP}", "port": 62023 },        { "node_id": "S4N25", "host": "${INSTANCE4_IP}", "port": 62024 },        { "node_id": "S4N26", "host": "${INSTANCE4_IP}", "port": 62025 },        { "node_id": "S4N27", "host": "${INSTANCE4_IP}", "port": 62026 },        { "node_id": "S4N28", "host": "${INSTANCE4_IP}", "port": 62027 },        { "node_id": "S4N29", "host": "${INSTANCE4_IP}", "port": 62028 },        { "node_id": "S4N30", "host": "${INSTANCE4_IP}", "port": 62029 },        { "node_id": "S4N31", "host": "${INSTANCE4_IP}", "port": 62030 },        { "node_id": "S4N32", "host": "${INSTANCE4_IP}", "port": 62031 },        { "node_id": "S4N33", "host": "${INSTANCE4_IP}", "port": 62032 },        { "node_id": "S4N34", "host": "${INSTANCE4_IP}", "port": 62033 },        { "node_id": "S4N35", "host": "${INSTANCE4_IP}", "port": 62034 },        { "node_id": "S4N36", "host": "${INSTANCE4_IP}", "port": 62035 },        { "node_id": "S4N37", "host": "${INSTANCE4_IP}", "port": 62036 },        { "node_id": "S4N38", "host": "${INSTANCE4_IP}", "port": 62037 },        { "node_id": "S4N39", "host": "${INSTANCE4_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-5/config.template.json
+++ b/deployment/aws/instance-5/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N40", "host": "${INSTANCE5_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S5N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S5N2", "host": "${INSTANCE5_IP}", "port": 62001 },        { "node_id": "S5N3", "host": "${INSTANCE5_IP}", "port": 62002 },        { "node_id": "S5N4", "host": "${INSTANCE5_IP}", "port": 62003 },        { "node_id": "S5N5", "host": "${INSTANCE5_IP}", "port": 62004 },        { "node_id": "S5N6", "host": "${INSTANCE5_IP}", "port": 62005 },        { "node_id": "S5N7", "host": "${INSTANCE5_IP}", "port": 62006 },        { "node_id": "S5N8", "host": "${INSTANCE5_IP}", "port": 62007 },        { "node_id": "S5N9", "host": "${INSTANCE5_IP}", "port": 62008 },        { "node_id": "S5N10", "host": "${INSTANCE5_IP}", "port": 62009 },        { "node_id": "S5N11", "host": "${INSTANCE5_IP}", "port": 62010 },        { "node_id": "S5N12", "host": "${INSTANCE5_IP}", "port": 62011 },        { "node_id": "S5N13", "host": "${INSTANCE5_IP}", "port": 62012 },        { "node_id": "S5N14", "host": "${INSTANCE5_IP}", "port": 62013 },        { "node_id": "S5N15", "host": "${INSTANCE5_IP}", "port": 62014 },        { "node_id": "S5N16", "host": "${INSTANCE5_IP}", "port": 62015 },        { "node_id": "S5N17", "host": "${INSTANCE5_IP}", "port": 62016 },        { "node_id": "S5N18", "host": "${INSTANCE5_IP}", "port": 62017 },        { "node_id": "S5N19", "host": "${INSTANCE5_IP}", "port": 62018 },        { "node_id": "S5N20", "host": "${INSTANCE5_IP}", "port": 62019 },        { "node_id": "S5N21", "host": "${INSTANCE5_IP}", "port": 62020 },        { "node_id": "S5N22", "host": "${INSTANCE5_IP}", "port": 62021 },        { "node_id": "S5N23", "host": "${INSTANCE5_IP}", "port": 62022 },        { "node_id": "S5N24", "host": "${INSTANCE5_IP}", "port": 62023 },        { "node_id": "S5N25", "host": "${INSTANCE5_IP}", "port": 62024 },        { "node_id": "S5N26", "host": "${INSTANCE5_IP}", "port": 62025 },        { "node_id": "S5N27", "host": "${INSTANCE5_IP}", "port": 62026 },        { "node_id": "S5N28", "host": "${INSTANCE5_IP}", "port": 62027 },        { "node_id": "S5N29", "host": "${INSTANCE5_IP}", "port": 62028 },        { "node_id": "S5N30", "host": "${INSTANCE5_IP}", "port": 62029 },        { "node_id": "S5N31", "host": "${INSTANCE5_IP}", "port": 62030 },        { "node_id": "S5N32", "host": "${INSTANCE5_IP}", "port": 62031 },        { "node_id": "S5N33", "host": "${INSTANCE5_IP}", "port": 62032 },        { "node_id": "S5N34", "host": "${INSTANCE5_IP}", "port": 62033 },        { "node_id": "S5N35", "host": "${INSTANCE5_IP}", "port": 62034 },        { "node_id": "S5N36", "host": "${INSTANCE5_IP}", "port": 62035 },        { "node_id": "S5N37", "host": "${INSTANCE5_IP}", "port": 62036 },        { "node_id": "S5N38", "host": "${INSTANCE5_IP}", "port": 62037 },        { "node_id": "S5N39", "host": "${INSTANCE5_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-6/config.template.json
+++ b/deployment/aws/instance-6/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N40", "host": "${INSTANCE6_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S6N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S6N2", "host": "${INSTANCE6_IP}", "port": 62001 },        { "node_id": "S6N3", "host": "${INSTANCE6_IP}", "port": 62002 },        { "node_id": "S6N4", "host": "${INSTANCE6_IP}", "port": 62003 },        { "node_id": "S6N5", "host": "${INSTANCE6_IP}", "port": 62004 },        { "node_id": "S6N6", "host": "${INSTANCE6_IP}", "port": 62005 },        { "node_id": "S6N7", "host": "${INSTANCE6_IP}", "port": 62006 },        { "node_id": "S6N8", "host": "${INSTANCE6_IP}", "port": 62007 },        { "node_id": "S6N9", "host": "${INSTANCE6_IP}", "port": 62008 },        { "node_id": "S6N10", "host": "${INSTANCE6_IP}", "port": 62009 },        { "node_id": "S6N11", "host": "${INSTANCE6_IP}", "port": 62010 },        { "node_id": "S6N12", "host": "${INSTANCE6_IP}", "port": 62011 },        { "node_id": "S6N13", "host": "${INSTANCE6_IP}", "port": 62012 },        { "node_id": "S6N14", "host": "${INSTANCE6_IP}", "port": 62013 },        { "node_id": "S6N15", "host": "${INSTANCE6_IP}", "port": 62014 },        { "node_id": "S6N16", "host": "${INSTANCE6_IP}", "port": 62015 },        { "node_id": "S6N17", "host": "${INSTANCE6_IP}", "port": 62016 },        { "node_id": "S6N18", "host": "${INSTANCE6_IP}", "port": 62017 },        { "node_id": "S6N19", "host": "${INSTANCE6_IP}", "port": 62018 },        { "node_id": "S6N20", "host": "${INSTANCE6_IP}", "port": 62019 },        { "node_id": "S6N21", "host": "${INSTANCE6_IP}", "port": 62020 },        { "node_id": "S6N22", "host": "${INSTANCE6_IP}", "port": 62021 },        { "node_id": "S6N23", "host": "${INSTANCE6_IP}", "port": 62022 },        { "node_id": "S6N24", "host": "${INSTANCE6_IP}", "port": 62023 },        { "node_id": "S6N25", "host": "${INSTANCE6_IP}", "port": 62024 },        { "node_id": "S6N26", "host": "${INSTANCE6_IP}", "port": 62025 },        { "node_id": "S6N27", "host": "${INSTANCE6_IP}", "port": 62026 },        { "node_id": "S6N28", "host": "${INSTANCE6_IP}", "port": 62027 },        { "node_id": "S6N29", "host": "${INSTANCE6_IP}", "port": 62028 },        { "node_id": "S6N30", "host": "${INSTANCE6_IP}", "port": 62029 },        { "node_id": "S6N31", "host": "${INSTANCE6_IP}", "port": 62030 },        { "node_id": "S6N32", "host": "${INSTANCE6_IP}", "port": 62031 },        { "node_id": "S6N33", "host": "${INSTANCE6_IP}", "port": 62032 },        { "node_id": "S6N34", "host": "${INSTANCE6_IP}", "port": 62033 },        { "node_id": "S6N35", "host": "${INSTANCE6_IP}", "port": 62034 },        { "node_id": "S6N36", "host": "${INSTANCE6_IP}", "port": 62035 },        { "node_id": "S6N37", "host": "${INSTANCE6_IP}", "port": 62036 },        { "node_id": "S6N38", "host": "${INSTANCE6_IP}", "port": 62037 },        { "node_id": "S6N39", "host": "${INSTANCE6_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-7/config.template.json
+++ b/deployment/aws/instance-7/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N40", "host": "${INSTANCE7_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S7N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S7N2", "host": "${INSTANCE7_IP}", "port": 62001 },        { "node_id": "S7N3", "host": "${INSTANCE7_IP}", "port": 62002 },        { "node_id": "S7N4", "host": "${INSTANCE7_IP}", "port": 62003 },        { "node_id": "S7N5", "host": "${INSTANCE7_IP}", "port": 62004 },        { "node_id": "S7N6", "host": "${INSTANCE7_IP}", "port": 62005 },        { "node_id": "S7N7", "host": "${INSTANCE7_IP}", "port": 62006 },        { "node_id": "S7N8", "host": "${INSTANCE7_IP}", "port": 62007 },        { "node_id": "S7N9", "host": "${INSTANCE7_IP}", "port": 62008 },        { "node_id": "S7N10", "host": "${INSTANCE7_IP}", "port": 62009 },        { "node_id": "S7N11", "host": "${INSTANCE7_IP}", "port": 62010 },        { "node_id": "S7N12", "host": "${INSTANCE7_IP}", "port": 62011 },        { "node_id": "S7N13", "host": "${INSTANCE7_IP}", "port": 62012 },        { "node_id": "S7N14", "host": "${INSTANCE7_IP}", "port": 62013 },        { "node_id": "S7N15", "host": "${INSTANCE7_IP}", "port": 62014 },        { "node_id": "S7N16", "host": "${INSTANCE7_IP}", "port": 62015 },        { "node_id": "S7N17", "host": "${INSTANCE7_IP}", "port": 62016 },        { "node_id": "S7N18", "host": "${INSTANCE7_IP}", "port": 62017 },        { "node_id": "S7N19", "host": "${INSTANCE7_IP}", "port": 62018 },        { "node_id": "S7N20", "host": "${INSTANCE7_IP}", "port": 62019 },        { "node_id": "S7N21", "host": "${INSTANCE7_IP}", "port": 62020 },        { "node_id": "S7N22", "host": "${INSTANCE7_IP}", "port": 62021 },        { "node_id": "S7N23", "host": "${INSTANCE7_IP}", "port": 62022 },        { "node_id": "S7N24", "host": "${INSTANCE7_IP}", "port": 62023 },        { "node_id": "S7N25", "host": "${INSTANCE7_IP}", "port": 62024 },        { "node_id": "S7N26", "host": "${INSTANCE7_IP}", "port": 62025 },        { "node_id": "S7N27", "host": "${INSTANCE7_IP}", "port": 62026 },        { "node_id": "S7N28", "host": "${INSTANCE7_IP}", "port": 62027 },        { "node_id": "S7N29", "host": "${INSTANCE7_IP}", "port": 62028 },        { "node_id": "S7N30", "host": "${INSTANCE7_IP}", "port": 62029 },        { "node_id": "S7N31", "host": "${INSTANCE7_IP}", "port": 62030 },        { "node_id": "S7N32", "host": "${INSTANCE7_IP}", "port": 62031 },        { "node_id": "S7N33", "host": "${INSTANCE7_IP}", "port": 62032 },        { "node_id": "S7N34", "host": "${INSTANCE7_IP}", "port": 62033 },        { "node_id": "S7N35", "host": "${INSTANCE7_IP}", "port": 62034 },        { "node_id": "S7N36", "host": "${INSTANCE7_IP}", "port": 62035 },        { "node_id": "S7N37", "host": "${INSTANCE7_IP}", "port": 62036 },        { "node_id": "S7N38", "host": "${INSTANCE7_IP}", "port": 62037 },        { "node_id": "S7N39", "host": "${INSTANCE7_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-8/config.template.json
+++ b/deployment/aws/instance-8/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N40", "host": "${INSTANCE8_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S8N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S8N2", "host": "${INSTANCE8_IP}", "port": 62001 },        { "node_id": "S8N3", "host": "${INSTANCE8_IP}", "port": 62002 },        { "node_id": "S8N4", "host": "${INSTANCE8_IP}", "port": 62003 },        { "node_id": "S8N5", "host": "${INSTANCE8_IP}", "port": 62004 },        { "node_id": "S8N6", "host": "${INSTANCE8_IP}", "port": 62005 },        { "node_id": "S8N7", "host": "${INSTANCE8_IP}", "port": 62006 },        { "node_id": "S8N8", "host": "${INSTANCE8_IP}", "port": 62007 },        { "node_id": "S8N9", "host": "${INSTANCE8_IP}", "port": 62008 },        { "node_id": "S8N10", "host": "${INSTANCE8_IP}", "port": 62009 },        { "node_id": "S8N11", "host": "${INSTANCE8_IP}", "port": 62010 },        { "node_id": "S8N12", "host": "${INSTANCE8_IP}", "port": 62011 },        { "node_id": "S8N13", "host": "${INSTANCE8_IP}", "port": 62012 },        { "node_id": "S8N14", "host": "${INSTANCE8_IP}", "port": 62013 },        { "node_id": "S8N15", "host": "${INSTANCE8_IP}", "port": 62014 },        { "node_id": "S8N16", "host": "${INSTANCE8_IP}", "port": 62015 },        { "node_id": "S8N17", "host": "${INSTANCE8_IP}", "port": 62016 },        { "node_id": "S8N18", "host": "${INSTANCE8_IP}", "port": 62017 },        { "node_id": "S8N19", "host": "${INSTANCE8_IP}", "port": 62018 },        { "node_id": "S8N20", "host": "${INSTANCE8_IP}", "port": 62019 },        { "node_id": "S8N21", "host": "${INSTANCE8_IP}", "port": 62020 },        { "node_id": "S8N22", "host": "${INSTANCE8_IP}", "port": 62021 },        { "node_id": "S8N23", "host": "${INSTANCE8_IP}", "port": 62022 },        { "node_id": "S8N24", "host": "${INSTANCE8_IP}", "port": 62023 },        { "node_id": "S8N25", "host": "${INSTANCE8_IP}", "port": 62024 },        { "node_id": "S8N26", "host": "${INSTANCE8_IP}", "port": 62025 },        { "node_id": "S8N27", "host": "${INSTANCE8_IP}", "port": 62026 },        { "node_id": "S8N28", "host": "${INSTANCE8_IP}", "port": 62027 },        { "node_id": "S8N29", "host": "${INSTANCE8_IP}", "port": 62028 },        { "node_id": "S8N30", "host": "${INSTANCE8_IP}", "port": 62029 },        { "node_id": "S8N31", "host": "${INSTANCE8_IP}", "port": 62030 },        { "node_id": "S8N32", "host": "${INSTANCE8_IP}", "port": 62031 },        { "node_id": "S8N33", "host": "${INSTANCE8_IP}", "port": 62032 },        { "node_id": "S8N34", "host": "${INSTANCE8_IP}", "port": 62033 },        { "node_id": "S8N35", "host": "${INSTANCE8_IP}", "port": 62034 },        { "node_id": "S8N36", "host": "${INSTANCE8_IP}", "port": 62035 },        { "node_id": "S8N37", "host": "${INSTANCE8_IP}", "port": 62036 },        { "node_id": "S8N38", "host": "${INSTANCE8_IP}", "port": 62037 },        { "node_id": "S8N39", "host": "${INSTANCE8_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],

--- a/deployment/aws/instance-9/config.template.json
+++ b/deployment/aws/instance-9/config.template.json
@@ -13,7 +13,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -23,7 +362,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -33,7 +711,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -43,7 +1060,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -53,7 +1409,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -63,7 +1758,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -73,7 +2107,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -83,7 +2456,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -93,7 +2805,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -103,7 +3154,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -113,7 +3503,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -123,7 +3852,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -133,7 +4201,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -143,7 +4550,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -153,7 +4899,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -163,7 +5248,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -173,7 +5597,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -183,7 +5946,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -193,7 +6295,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     },
     {
@@ -203,207 +6644,346 @@
       "storage_kb": 8192,
       "bootstrap": "none",
       "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N21",
-      "host": "0.0.0.0",
-      "port": 62020,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N22",
-      "host": "0.0.0.0",
-      "port": 62021,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N23",
-      "host": "0.0.0.0",
-      "port": 62022,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N24",
-      "host": "0.0.0.0",
-      "port": 62023,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N25",
-      "host": "0.0.0.0",
-      "port": 62024,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N26",
-      "host": "0.0.0.0",
-      "port": 62025,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N27",
-      "host": "0.0.0.0",
-      "port": 62026,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N28",
-      "host": "0.0.0.0",
-      "port": 62027,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N29",
-      "host": "0.0.0.0",
-      "port": 62028,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N30",
-      "host": "0.0.0.0",
-      "port": 62029,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N31",
-      "host": "0.0.0.0",
-      "port": 62030,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N32",
-      "host": "0.0.0.0",
-      "port": 62031,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N33",
-      "host": "0.0.0.0",
-      "port": 62032,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N34",
-      "host": "0.0.0.0",
-      "port": 62033,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N35",
-      "host": "0.0.0.0",
-      "port": 62034,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N36",
-      "host": "0.0.0.0",
-      "port": 62035,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N37",
-      "host": "0.0.0.0",
-      "port": 62036,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N38",
-      "host": "0.0.0.0",
-      "port": 62037,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N39",
-      "host": "0.0.0.0",
-      "port": 62038,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N40", "host": "${INSTANCE9_IP}", "port": 62039 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
-      ]
-    },
-    {
-      "node_id": "S9N40",
-      "host": "0.0.0.0",
-      "port": 62039,
-      "storage_kb": 8192,
-      "bootstrap": "none",
-      "peers": [
-        { "node_id": "S9N1", "host": "${INSTANCE9_IP}", "port": 62000 },        { "node_id": "S9N2", "host": "${INSTANCE9_IP}", "port": 62001 },        { "node_id": "S9N3", "host": "${INSTANCE9_IP}", "port": 62002 },        { "node_id": "S9N4", "host": "${INSTANCE9_IP}", "port": 62003 },        { "node_id": "S9N5", "host": "${INSTANCE9_IP}", "port": 62004 },        { "node_id": "S9N6", "host": "${INSTANCE9_IP}", "port": 62005 },        { "node_id": "S9N7", "host": "${INSTANCE9_IP}", "port": 62006 },        { "node_id": "S9N8", "host": "${INSTANCE9_IP}", "port": 62007 },        { "node_id": "S9N9", "host": "${INSTANCE9_IP}", "port": 62008 },        { "node_id": "S9N10", "host": "${INSTANCE9_IP}", "port": 62009 },        { "node_id": "S9N11", "host": "${INSTANCE9_IP}", "port": 62010 },        { "node_id": "S9N12", "host": "${INSTANCE9_IP}", "port": 62011 },        { "node_id": "S9N13", "host": "${INSTANCE9_IP}", "port": 62012 },        { "node_id": "S9N14", "host": "${INSTANCE9_IP}", "port": 62013 },        { "node_id": "S9N15", "host": "${INSTANCE9_IP}", "port": 62014 },        { "node_id": "S9N16", "host": "${INSTANCE9_IP}", "port": 62015 },        { "node_id": "S9N17", "host": "${INSTANCE9_IP}", "port": 62016 },        { "node_id": "S9N18", "host": "${INSTANCE9_IP}", "port": 62017 },        { "node_id": "S9N19", "host": "${INSTANCE9_IP}", "port": 62018 },        { "node_id": "S9N20", "host": "${INSTANCE9_IP}", "port": 62019 },        { "node_id": "S9N21", "host": "${INSTANCE9_IP}", "port": 62020 },        { "node_id": "S9N22", "host": "${INSTANCE9_IP}", "port": 62021 },        { "node_id": "S9N23", "host": "${INSTANCE9_IP}", "port": 62022 },        { "node_id": "S9N24", "host": "${INSTANCE9_IP}", "port": 62023 },        { "node_id": "S9N25", "host": "${INSTANCE9_IP}", "port": 62024 },        { "node_id": "S9N26", "host": "${INSTANCE9_IP}", "port": 62025 },        { "node_id": "S9N27", "host": "${INSTANCE9_IP}", "port": 62026 },        { "node_id": "S9N28", "host": "${INSTANCE9_IP}", "port": 62027 },        { "node_id": "S9N29", "host": "${INSTANCE9_IP}", "port": 62028 },        { "node_id": "S9N30", "host": "${INSTANCE9_IP}", "port": 62029 },        { "node_id": "S9N31", "host": "${INSTANCE9_IP}", "port": 62030 },        { "node_id": "S9N32", "host": "${INSTANCE9_IP}", "port": 62031 },        { "node_id": "S9N33", "host": "${INSTANCE9_IP}", "port": 62032 },        { "node_id": "S9N34", "host": "${INSTANCE9_IP}", "port": 62033 },        { "node_id": "S9N35", "host": "${INSTANCE9_IP}", "port": 62034 },        { "node_id": "S9N36", "host": "${INSTANCE9_IP}", "port": 62035 },        { "node_id": "S9N37", "host": "${INSTANCE9_IP}", "port": 62036 },        { "node_id": "S9N38", "host": "${INSTANCE9_IP}", "port": 62037 },        { "node_id": "S9N39", "host": "${INSTANCE9_IP}", "port": 62038 },        { "node_id": "S1N1", "host": "${INSTANCE1_IP}", "port": 62000 },        { "node_id": "S2N1", "host": "${INSTANCE2_IP}", "port": 62000 },        { "node_id": "S3N1", "host": "${INSTANCE3_IP}", "port": 62000 },        { "node_id": "S4N1", "host": "${INSTANCE4_IP}", "port": 62000 },        { "node_id": "S5N1", "host": "${INSTANCE5_IP}", "port": 62000 },        { "node_id": "S6N1", "host": "${INSTANCE6_IP}", "port": 62000 },        { "node_id": "S7N1", "host": "${INSTANCE7_IP}", "port": 62000 },        { "node_id": "S8N1", "host": "${INSTANCE8_IP}", "port": 62000 },        { "node_id": "S10N1", "host": "${INSTANCE10_IP}", "port": 62000 },        { "node_id": "S11N1", "host": "${INSTANCE11_IP}", "port": 62000 },        { "node_id": "S12N1", "host": "${INSTANCE12_IP}", "port": 62000 },        { "node_id": "S13N1", "host": "${INSTANCE13_IP}", "port": 62000 },        { "node_id": "S14N1", "host": "${INSTANCE14_IP}", "port": 62000 },        { "node_id": "S15N1", "host": "${INSTANCE15_IP}", "port": 62000 },        { "node_id": "S16N1", "host": "${INSTANCE16_IP}", "port": 62000 },        { "node_id": "S17N1", "host": "${INSTANCE17_IP}", "port": 62000 },        { "node_id": "S18N1", "host": "${INSTANCE18_IP}", "port": 62000 },        { "node_id": "S19N1", "host": "${INSTANCE19_IP}", "port": 62000 },        { "node_id": "S20N1", "host": "${INSTANCE20_IP}", "port": 62000 },        { "node_id": "S21N1", "host": "${INSTANCE21_IP}", "port": 62000 },        { "node_id": "S22N1", "host": "${INSTANCE22_IP}", "port": 62000 },        { "node_id": "S23N1", "host": "${INSTANCE23_IP}", "port": 62000 },        { "node_id": "S24N1", "host": "${INSTANCE24_IP}", "port": 62000 },        { "node_id": "S25N1", "host": "${INSTANCE25_IP}", "port": 62000 },        { "node_id": "S26N1", "host": "${INSTANCE26_IP}", "port": 62000 },        { "node_id": "S27N1", "host": "${INSTANCE27_IP}", "port": 62000 },        { "node_id": "S28N1", "host": "${INSTANCE28_IP}", "port": 62000 },        { "node_id": "S29N1", "host": "${INSTANCE29_IP}", "port": 62000 },        { "node_id": "S30N1", "host": "${INSTANCE30_IP}", "port": 62000 },        { "node_id": "S31N1", "host": "${INSTANCE31_IP}", "port": 62000 },        { "node_id": "S32N1", "host": "${INSTANCE32_IP}", "port": 62000 },        { "node_id": "S33N1", "host": "${INSTANCE33_IP}", "port": 62000 },        { "node_id": "S34N1", "host": "${INSTANCE34_IP}", "port": 62000 },        { "node_id": "S35N1", "host": "${INSTANCE35_IP}", "port": 62000 },        { "node_id": "S36N1", "host": "${INSTANCE36_IP}", "port": 62000 },        { "node_id": "S37N1", "host": "${INSTANCE37_IP}", "port": 62000 },        { "node_id": "S38N1", "host": "${INSTANCE38_IP}", "port": 62000 },        { "node_id": "S39N1", "host": "${INSTANCE39_IP}", "port": 62000 },        { "node_id": "S40N1", "host": "${INSTANCE40_IP}", "port": 62000 },        { "node_id": "S41N1", "host": "${INSTANCE41_IP}", "port": 62000 },        { "node_id": "S42N1", "host": "${INSTANCE42_IP}", "port": 62000 },        { "node_id": "S43N1", "host": "${INSTANCE43_IP}", "port": 62000 },        { "node_id": "S44N1", "host": "${INSTANCE44_IP}", "port": 62000 },        { "node_id": "S45N1", "host": "${INSTANCE45_IP}", "port": 62000 },        { "node_id": "S46N1", "host": "${INSTANCE46_IP}", "port": 62000 },        { "node_id": "S47N1", "host": "${INSTANCE47_IP}", "port": 62000 },        { "node_id": "S48N1", "host": "${INSTANCE48_IP}", "port": 62000 },        { "node_id": "S49N1", "host": "${INSTANCE49_IP}", "port": 62000 },        { "node_id": "S50N1", "host": "${INSTANCE50_IP}", "port": 62000 }
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S41N1",
+          "host": "${INSTANCE41_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S42N1",
+          "host": "${INSTANCE42_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S43N1",
+          "host": "${INSTANCE43_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S44N1",
+          "host": "${INSTANCE44_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S45N1",
+          "host": "${INSTANCE45_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S46N1",
+          "host": "${INSTANCE46_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S47N1",
+          "host": "${INSTANCE47_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S48N1",
+          "host": "${INSTANCE48_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S49N1",
+          "host": "${INSTANCE49_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S50N1",
+          "host": "${INSTANCE50_IP}",
+          "port": 62000
+        }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- trim the node definitions in the AWS deployment templates for instances 1-10 to only include 20 nodes each
- update peer lists so that same-instance references no longer point to the removed nodes while keeping cross-instance connectivity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e71185931083279c471d94d311a706