### PR TITLE
Ensure AWS nodes bind to all interfaces

### DIFF
--- a/deployment/aws/instance-1/config.template.json
+++ b/deployment/aws/instance-1/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S1N2",
-      "host": "${INSTANCE1_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S1N3",
-      "host": "${INSTANCE1_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S1N4",
-      "host": "${INSTANCE1_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S1N5",
-      "host": "${INSTANCE1_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S1N6",
-      "host": "${INSTANCE1_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S1N7",
-      "host": "${INSTANCE1_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-10/config.template.json
+++ b/deployment/aws/instance-10/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S10N2",
-      "host": "${INSTANCE10_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S10N3",
-      "host": "${INSTANCE10_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S10N4",
-      "host": "${INSTANCE10_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S10N5",
-      "host": "${INSTANCE10_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S10N6",
-      "host": "${INSTANCE10_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S10N7",
-      "host": "${INSTANCE10_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-11/config.template.json
+++ b/deployment/aws/instance-11/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S11N2",
-      "host": "${INSTANCE11_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S11N3",
-      "host": "${INSTANCE11_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S11N4",
-      "host": "${INSTANCE11_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S11N5",
-      "host": "${INSTANCE11_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S11N6",
-      "host": "${INSTANCE11_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S11N7",
-      "host": "${INSTANCE11_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-12/config.template.json
+++ b/deployment/aws/instance-12/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S12N2",
-      "host": "${INSTANCE12_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S12N3",
-      "host": "${INSTANCE12_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S12N4",
-      "host": "${INSTANCE12_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S12N5",
-      "host": "${INSTANCE12_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S12N6",
-      "host": "${INSTANCE12_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S12N7",
-      "host": "${INSTANCE12_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-13/config.template.json
+++ b/deployment/aws/instance-13/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S13N2",
-      "host": "${INSTANCE13_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S13N3",
-      "host": "${INSTANCE13_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S13N4",
-      "host": "${INSTANCE13_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S13N5",
-      "host": "${INSTANCE13_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S13N6",
-      "host": "${INSTANCE13_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S13N7",
-      "host": "${INSTANCE13_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-14/config.template.json
+++ b/deployment/aws/instance-14/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S14N2",
-      "host": "${INSTANCE14_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S14N3",
-      "host": "${INSTANCE14_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S14N4",
-      "host": "${INSTANCE14_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S14N5",
-      "host": "${INSTANCE14_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S14N6",
-      "host": "${INSTANCE14_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S14N7",
-      "host": "${INSTANCE14_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-15/config.template.json
+++ b/deployment/aws/instance-15/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S15N2",
-      "host": "${INSTANCE15_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S15N3",
-      "host": "${INSTANCE15_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S15N4",
-      "host": "${INSTANCE15_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S15N5",
-      "host": "${INSTANCE15_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S15N6",
-      "host": "${INSTANCE15_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S15N7",
-      "host": "${INSTANCE15_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-16/config.template.json
+++ b/deployment/aws/instance-16/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S16N2",
-      "host": "${INSTANCE16_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S16N3",
-      "host": "${INSTANCE16_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S16N4",
-      "host": "${INSTANCE16_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S16N5",
-      "host": "${INSTANCE16_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S16N6",
-      "host": "${INSTANCE16_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S16N7",
-      "host": "${INSTANCE16_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-17/config.template.json
+++ b/deployment/aws/instance-17/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S17N2",
-      "host": "${INSTANCE17_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S17N3",
-      "host": "${INSTANCE17_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S17N4",
-      "host": "${INSTANCE17_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S17N5",
-      "host": "${INSTANCE17_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S17N6",
-      "host": "${INSTANCE17_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S17N7",
-      "host": "${INSTANCE17_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-18/config.template.json
+++ b/deployment/aws/instance-18/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S18N2",
-      "host": "${INSTANCE18_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S18N3",
-      "host": "${INSTANCE18_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S18N4",
-      "host": "${INSTANCE18_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S18N5",
-      "host": "${INSTANCE18_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S18N6",
-      "host": "${INSTANCE18_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S18N7",
-      "host": "${INSTANCE18_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-19/config.template.json
+++ b/deployment/aws/instance-19/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S19N2",
-      "host": "${INSTANCE19_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S19N3",
-      "host": "${INSTANCE19_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S19N4",
-      "host": "${INSTANCE19_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S19N5",
-      "host": "${INSTANCE19_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S19N6",
-      "host": "${INSTANCE19_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S19N7",
-      "host": "${INSTANCE19_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-2/config.template.json
+++ b/deployment/aws/instance-2/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S2N2",
-      "host": "${INSTANCE2_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S2N3",
-      "host": "${INSTANCE2_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S2N4",
-      "host": "${INSTANCE2_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S2N5",
-      "host": "${INSTANCE2_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S2N6",
-      "host": "${INSTANCE2_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S2N7",
-      "host": "${INSTANCE2_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-20/config.template.json
+++ b/deployment/aws/instance-20/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S20N2",
-      "host": "${INSTANCE20_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S20N3",
-      "host": "${INSTANCE20_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S20N4",
-      "host": "${INSTANCE20_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S20N5",
-      "host": "${INSTANCE20_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S20N6",
-      "host": "${INSTANCE20_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S20N7",
-      "host": "${INSTANCE20_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-21/config.template.json
+++ b/deployment/aws/instance-21/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S21N2",
-      "host": "${INSTANCE21_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S21N3",
-      "host": "${INSTANCE21_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S21N4",
-      "host": "${INSTANCE21_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S21N5",
-      "host": "${INSTANCE21_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S21N6",
-      "host": "${INSTANCE21_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S21N7",
-      "host": "${INSTANCE21_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-22/config.template.json
+++ b/deployment/aws/instance-22/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S22N2",
-      "host": "${INSTANCE22_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S22N3",
-      "host": "${INSTANCE22_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S22N4",
-      "host": "${INSTANCE22_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S22N5",
-      "host": "${INSTANCE22_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S22N6",
-      "host": "${INSTANCE22_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S22N7",
-      "host": "${INSTANCE22_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-23/config.template.json
+++ b/deployment/aws/instance-23/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S23N2",
-      "host": "${INSTANCE23_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S23N3",
-      "host": "${INSTANCE23_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S23N4",
-      "host": "${INSTANCE23_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S23N5",
-      "host": "${INSTANCE23_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S23N6",
-      "host": "${INSTANCE23_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S23N7",
-      "host": "${INSTANCE23_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-24/config.template.json
+++ b/deployment/aws/instance-24/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S24N2",
-      "host": "${INSTANCE24_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S24N3",
-      "host": "${INSTANCE24_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S24N4",
-      "host": "${INSTANCE24_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S24N5",
-      "host": "${INSTANCE24_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S24N6",
-      "host": "${INSTANCE24_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S24N7",
-      "host": "${INSTANCE24_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-25/config.template.json
+++ b/deployment/aws/instance-25/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S25N2",
-      "host": "${INSTANCE25_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S25N3",
-      "host": "${INSTANCE25_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S25N4",
-      "host": "${INSTANCE25_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S25N5",
-      "host": "${INSTANCE25_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S25N6",
-      "host": "${INSTANCE25_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S25N7",
-      "host": "${INSTANCE25_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-26/config.template.json
+++ b/deployment/aws/instance-26/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S26N2",
-      "host": "${INSTANCE26_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S26N3",
-      "host": "${INSTANCE26_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S26N4",
-      "host": "${INSTANCE26_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S26N5",
-      "host": "${INSTANCE26_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S26N6",
-      "host": "${INSTANCE26_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S26N7",
-      "host": "${INSTANCE26_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-27/config.template.json
+++ b/deployment/aws/instance-27/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S27N2",
-      "host": "${INSTANCE27_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S27N3",
-      "host": "${INSTANCE27_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S27N4",
-      "host": "${INSTANCE27_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S27N5",
-      "host": "${INSTANCE27_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S27N6",
-      "host": "${INSTANCE27_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S27N7",
-      "host": "${INSTANCE27_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-28/config.template.json
+++ b/deployment/aws/instance-28/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S28N2",
-      "host": "${INSTANCE28_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S28N3",
-      "host": "${INSTANCE28_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S28N4",
-      "host": "${INSTANCE28_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S28N5",
-      "host": "${INSTANCE28_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S28N6",
-      "host": "${INSTANCE28_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S28N7",
-      "host": "${INSTANCE28_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-29/config.template.json
+++ b/deployment/aws/instance-29/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S29N2",
-      "host": "${INSTANCE29_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S29N3",
-      "host": "${INSTANCE29_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S29N4",
-      "host": "${INSTANCE29_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S29N5",
-      "host": "${INSTANCE29_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S29N6",
-      "host": "${INSTANCE29_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S29N7",
-      "host": "${INSTANCE29_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-3/config.template.json
+++ b/deployment/aws/instance-3/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S3N2",
-      "host": "${INSTANCE3_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S3N3",
-      "host": "${INSTANCE3_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S3N4",
-      "host": "${INSTANCE3_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S3N5",
-      "host": "${INSTANCE3_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S3N6",
-      "host": "${INSTANCE3_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S3N7",
-      "host": "${INSTANCE3_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-30/config.template.json
+++ b/deployment/aws/instance-30/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S30N2",
-      "host": "${INSTANCE30_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S30N3",
-      "host": "${INSTANCE30_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S30N4",
-      "host": "${INSTANCE30_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S30N5",
-      "host": "${INSTANCE30_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S30N6",
-      "host": "${INSTANCE30_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S30N7",
-      "host": "${INSTANCE30_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-31/config.template.json
+++ b/deployment/aws/instance-31/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S31N2",
-      "host": "${INSTANCE31_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S31N3",
-      "host": "${INSTANCE31_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S31N4",
-      "host": "${INSTANCE31_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S31N5",
-      "host": "${INSTANCE31_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S31N6",
-      "host": "${INSTANCE31_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S31N7",
-      "host": "${INSTANCE31_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-32/config.template.json
+++ b/deployment/aws/instance-32/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S32N2",
-      "host": "${INSTANCE32_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S32N3",
-      "host": "${INSTANCE32_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S32N4",
-      "host": "${INSTANCE32_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S32N5",
-      "host": "${INSTANCE32_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S32N6",
-      "host": "${INSTANCE32_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S32N7",
-      "host": "${INSTANCE32_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-33/config.template.json
+++ b/deployment/aws/instance-33/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S33N2",
-      "host": "${INSTANCE33_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S33N3",
-      "host": "${INSTANCE33_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S33N4",
-      "host": "${INSTANCE33_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S33N5",
-      "host": "${INSTANCE33_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S33N6",
-      "host": "${INSTANCE33_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S33N7",
-      "host": "${INSTANCE33_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-34/config.template.json
+++ b/deployment/aws/instance-34/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S34N2",
-      "host": "${INSTANCE34_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S34N3",
-      "host": "${INSTANCE34_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S34N4",
-      "host": "${INSTANCE34_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S34N5",
-      "host": "${INSTANCE34_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S34N6",
-      "host": "${INSTANCE34_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S34N7",
-      "host": "${INSTANCE34_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-35/config.template.json
+++ b/deployment/aws/instance-35/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S35N2",
-      "host": "${INSTANCE35_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S35N3",
-      "host": "${INSTANCE35_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S35N4",
-      "host": "${INSTANCE35_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S35N5",
-      "host": "${INSTANCE35_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S35N6",
-      "host": "${INSTANCE35_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S35N7",
-      "host": "${INSTANCE35_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-36/config.template.json
+++ b/deployment/aws/instance-36/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S36N2",
-      "host": "${INSTANCE36_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S36N3",
-      "host": "${INSTANCE36_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S36N4",
-      "host": "${INSTANCE36_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S36N5",
-      "host": "${INSTANCE36_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S36N6",
-      "host": "${INSTANCE36_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S36N7",
-      "host": "${INSTANCE36_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-37/config.template.json
+++ b/deployment/aws/instance-37/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S37N2",
-      "host": "${INSTANCE37_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S37N3",
-      "host": "${INSTANCE37_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S37N4",
-      "host": "${INSTANCE37_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S37N5",
-      "host": "${INSTANCE37_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S37N6",
-      "host": "${INSTANCE37_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S37N7",
-      "host": "${INSTANCE37_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-38/config.template.json
+++ b/deployment/aws/instance-38/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S38N2",
-      "host": "${INSTANCE38_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S38N3",
-      "host": "${INSTANCE38_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S38N4",
-      "host": "${INSTANCE38_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S38N5",
-      "host": "${INSTANCE38_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S38N6",
-      "host": "${INSTANCE38_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S38N7",
-      "host": "${INSTANCE38_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-39/config.template.json
+++ b/deployment/aws/instance-39/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S39N2",
-      "host": "${INSTANCE39_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S39N3",
-      "host": "${INSTANCE39_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S39N4",
-      "host": "${INSTANCE39_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S39N5",
-      "host": "${INSTANCE39_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S39N6",
-      "host": "${INSTANCE39_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S39N7",
-      "host": "${INSTANCE39_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-4/config.template.json
+++ b/deployment/aws/instance-4/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S4N2",
-      "host": "${INSTANCE4_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S4N3",
-      "host": "${INSTANCE4_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S4N4",
-      "host": "${INSTANCE4_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S4N5",
-      "host": "${INSTANCE4_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S4N6",
-      "host": "${INSTANCE4_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S4N7",
-      "host": "${INSTANCE4_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-40/config.template.json
+++ b/deployment/aws/instance-40/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S40N2",
-      "host": "${INSTANCE40_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S40N3",
-      "host": "${INSTANCE40_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S40N4",
-      "host": "${INSTANCE40_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S40N5",
-      "host": "${INSTANCE40_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S40N6",
-      "host": "${INSTANCE40_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S40N7",
-      "host": "${INSTANCE40_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-41/config.template.json
+++ b/deployment/aws/instance-41/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S41N2",
-      "host": "${INSTANCE41_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S41N3",
-      "host": "${INSTANCE41_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S41N4",
-      "host": "${INSTANCE41_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S41N5",
-      "host": "${INSTANCE41_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S41N6",
-      "host": "${INSTANCE41_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S41N7",
-      "host": "${INSTANCE41_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-42/config.template.json
+++ b/deployment/aws/instance-42/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S42N2",
-      "host": "${INSTANCE42_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S42N3",
-      "host": "${INSTANCE42_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S42N4",
-      "host": "${INSTANCE42_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S42N5",
-      "host": "${INSTANCE42_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S42N6",
-      "host": "${INSTANCE42_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S42N7",
-      "host": "${INSTANCE42_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-43/config.template.json
+++ b/deployment/aws/instance-43/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S43N2",
-      "host": "${INSTANCE43_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S43N3",
-      "host": "${INSTANCE43_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S43N4",
-      "host": "${INSTANCE43_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S43N5",
-      "host": "${INSTANCE43_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S43N6",
-      "host": "${INSTANCE43_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S43N7",
-      "host": "${INSTANCE43_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-44/config.template.json
+++ b/deployment/aws/instance-44/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S44N2",
-      "host": "${INSTANCE44_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S44N3",
-      "host": "${INSTANCE44_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S44N4",
-      "host": "${INSTANCE44_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S44N5",
-      "host": "${INSTANCE44_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S44N6",
-      "host": "${INSTANCE44_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S44N7",
-      "host": "${INSTANCE44_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-45/config.template.json
+++ b/deployment/aws/instance-45/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S45N2",
-      "host": "${INSTANCE45_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S45N3",
-      "host": "${INSTANCE45_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S45N4",
-      "host": "${INSTANCE45_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S45N5",
-      "host": "${INSTANCE45_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S45N6",
-      "host": "${INSTANCE45_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S45N7",
-      "host": "${INSTANCE45_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-46/config.template.json
+++ b/deployment/aws/instance-46/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S46N2",
-      "host": "${INSTANCE46_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S46N3",
-      "host": "${INSTANCE46_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S46N4",
-      "host": "${INSTANCE46_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S46N5",
-      "host": "${INSTANCE46_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S46N6",
-      "host": "${INSTANCE46_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S46N7",
-      "host": "${INSTANCE46_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-47/config.template.json
+++ b/deployment/aws/instance-47/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S47N2",
-      "host": "${INSTANCE47_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S47N3",
-      "host": "${INSTANCE47_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S47N4",
-      "host": "${INSTANCE47_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S47N5",
-      "host": "${INSTANCE47_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S47N6",
-      "host": "${INSTANCE47_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S47N7",
-      "host": "${INSTANCE47_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-48/config.template.json
+++ b/deployment/aws/instance-48/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S48N2",
-      "host": "${INSTANCE48_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S48N3",
-      "host": "${INSTANCE48_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S48N4",
-      "host": "${INSTANCE48_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S48N5",
-      "host": "${INSTANCE48_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S48N6",
-      "host": "${INSTANCE48_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S48N7",
-      "host": "${INSTANCE48_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-49/config.template.json
+++ b/deployment/aws/instance-49/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S49N2",
-      "host": "${INSTANCE49_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S49N3",
-      "host": "${INSTANCE49_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S49N4",
-      "host": "${INSTANCE49_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S49N5",
-      "host": "${INSTANCE49_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S49N6",
-      "host": "${INSTANCE49_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S49N7",
-      "host": "${INSTANCE49_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-5/config.template.json
+++ b/deployment/aws/instance-5/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S5N2",
-      "host": "${INSTANCE5_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S5N3",
-      "host": "${INSTANCE5_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S5N4",
-      "host": "${INSTANCE5_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S5N5",
-      "host": "${INSTANCE5_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S5N6",
-      "host": "${INSTANCE5_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S5N7",
-      "host": "${INSTANCE5_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-50/config.template.json
+++ b/deployment/aws/instance-50/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S50N2",
-      "host": "${INSTANCE50_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S50N3",
-      "host": "${INSTANCE50_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S50N4",
-      "host": "${INSTANCE50_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S50N5",
-      "host": "${INSTANCE50_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S50N6",
-      "host": "${INSTANCE50_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S50N7",
-      "host": "${INSTANCE50_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-6/config.template.json
+++ b/deployment/aws/instance-6/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S6N2",
-      "host": "${INSTANCE6_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S6N3",
-      "host": "${INSTANCE6_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S6N4",
-      "host": "${INSTANCE6_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S6N5",
-      "host": "${INSTANCE6_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S6N6",
-      "host": "${INSTANCE6_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S6N7",
-      "host": "${INSTANCE6_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-7/config.template.json
+++ b/deployment/aws/instance-7/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S7N2",
-      "host": "${INSTANCE7_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S7N3",
-      "host": "${INSTANCE7_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S7N4",
-      "host": "${INSTANCE7_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S7N5",
-      "host": "${INSTANCE7_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S7N6",
-      "host": "${INSTANCE7_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S7N7",
-      "host": "${INSTANCE7_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-8/config.template.json
+++ b/deployment/aws/instance-8/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S8N2",
-      "host": "${INSTANCE8_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S8N3",
-      "host": "${INSTANCE8_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S8N4",
-      "host": "${INSTANCE8_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S8N5",
-      "host": "${INSTANCE8_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S8N6",
-      "host": "${INSTANCE8_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S8N7",
-      "host": "${INSTANCE8_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {

--- a/deployment/aws/instance-9/config.template.json
+++ b/deployment/aws/instance-9/config.template.json
@@ -292,7 +292,7 @@
     },
     {
       "node_id": "S9N2",
-      "host": "${INSTANCE9_IP}",
+      "host": "0.0.0.0",
       "port": 62001,
       "peers": [
         {
@@ -574,7 +574,7 @@
     },
     {
       "node_id": "S9N3",
-      "host": "${INSTANCE9_IP}",
+      "host": "0.0.0.0",
       "port": 62002,
       "peers": [
         {
@@ -856,7 +856,7 @@
     },
     {
       "node_id": "S9N4",
-      "host": "${INSTANCE9_IP}",
+      "host": "0.0.0.0",
       "port": 62003,
       "peers": [
         {
@@ -1138,7 +1138,7 @@
     },
     {
       "node_id": "S9N5",
-      "host": "${INSTANCE9_IP}",
+      "host": "0.0.0.0",
       "port": 62004,
       "peers": [
         {
@@ -1420,7 +1420,7 @@
     },
     {
       "node_id": "S9N6",
-      "host": "${INSTANCE9_IP}",
+      "host": "0.0.0.0",
       "port": 62005,
       "peers": [
         {
@@ -1702,7 +1702,7 @@
     },
     {
       "node_id": "S9N7",
-      "host": "${INSTANCE9_IP}",
+      "host": "0.0.0.0",
       "port": 62006,
       "peers": [
         {


### PR DESCRIPTION
## Summary
- set each AWS instance config template's local node hosts to 0.0.0.0 while leaving peer definitions unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7494547648327a4bc0f0fa6de9914