### PR TITLE
Align bootstrap nodes to S1N1

### DIFF
--- a/deployment/aws/instance-1/config.template.json
+++ b/deployment/aws/instance-1/config.template.json
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S1N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S1N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S1N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S1N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S1N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [

--- a/deployment/aws/instance-10/config.template.json
+++ b/deployment/aws/instance-10/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S10N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S10N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S10N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S10N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S10N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S10N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U10",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE10_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-11/config.template.json
+++ b/deployment/aws/instance-11/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S11N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S11N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S11N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S11N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S11N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S11N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U11",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE11_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-12/config.template.json
+++ b/deployment/aws/instance-12/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S12N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S12N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S12N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S12N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S12N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S12N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U12",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE12_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-13/config.template.json
+++ b/deployment/aws/instance-13/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S13N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S13N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S13N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S13N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S13N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S13N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U13",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE13_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-14/config.template.json
+++ b/deployment/aws/instance-14/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S14N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S14N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S14N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S14N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S14N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S14N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U14",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE14_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-15/config.template.json
+++ b/deployment/aws/instance-15/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S15N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S15N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S15N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S15N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S15N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S15N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U15",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE15_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-16/config.template.json
+++ b/deployment/aws/instance-16/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S16N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S16N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S16N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S16N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S16N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S16N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U16",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE16_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-17/config.template.json
+++ b/deployment/aws/instance-17/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S17N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S17N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S17N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S17N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S17N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S17N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U17",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE17_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-18/config.template.json
+++ b/deployment/aws/instance-18/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S18N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S18N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S18N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S18N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S18N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S18N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U18",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE18_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-19/config.template.json
+++ b/deployment/aws/instance-19/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S19N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S19N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S19N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S19N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S19N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S19N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U19",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE19_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-2/config.template.json
+++ b/deployment/aws/instance-2/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S2N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S2N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S2N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S2N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S2N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S2N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U2",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE2_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-20/config.template.json
+++ b/deployment/aws/instance-20/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S20N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S20N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S20N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S20N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S20N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S20N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U20",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE20_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-21/config.template.json
+++ b/deployment/aws/instance-21/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S21N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S21N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S21N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S21N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S21N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S21N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U21",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE21_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-22/config.template.json
+++ b/deployment/aws/instance-22/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S22N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S22N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S22N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S22N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S22N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S22N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U22",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE22_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-23/config.template.json
+++ b/deployment/aws/instance-23/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S23N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S23N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S23N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S23N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S23N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S23N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U23",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE23_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-24/config.template.json
+++ b/deployment/aws/instance-24/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S24N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S24N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S24N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S24N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S24N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S24N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U24",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE24_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-25/config.template.json
+++ b/deployment/aws/instance-25/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S25N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S25N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S25N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S25N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S25N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S25N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U25",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE25_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-26/config.template.json
+++ b/deployment/aws/instance-26/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S26N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S26N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S26N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S26N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S26N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S26N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U26",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE26_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-27/config.template.json
+++ b/deployment/aws/instance-27/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S27N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S27N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S27N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S27N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S27N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S27N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U27",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE27_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-28/config.template.json
+++ b/deployment/aws/instance-28/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S28N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S28N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S28N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S28N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S28N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S28N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U28",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE28_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-29/config.template.json
+++ b/deployment/aws/instance-29/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S29N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S29N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S29N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S29N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S29N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S29N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U29",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE29_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-3/config.template.json
+++ b/deployment/aws/instance-3/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S3N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S3N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S3N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S3N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S3N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S3N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U3",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE3_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-30/config.template.json
+++ b/deployment/aws/instance-30/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S30N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S30N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S30N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S30N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S30N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S30N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U30",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE30_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-31/config.template.json
+++ b/deployment/aws/instance-31/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S31N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S31N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S31N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S31N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S31N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S31N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U31",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE31_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-32/config.template.json
+++ b/deployment/aws/instance-32/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S32N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S32N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S32N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S32N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S32N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S32N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U32",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE32_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-33/config.template.json
+++ b/deployment/aws/instance-33/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S33N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S33N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S33N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S33N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S33N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S33N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U33",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE33_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-34/config.template.json
+++ b/deployment/aws/instance-34/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S34N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S34N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S34N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S34N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S34N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S34N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U34",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE34_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-35/config.template.json
+++ b/deployment/aws/instance-35/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S35N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S35N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S35N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S35N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S35N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S35N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U35",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE35_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-36/config.template.json
+++ b/deployment/aws/instance-36/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S36N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S36N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S36N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S36N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S36N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S36N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U36",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE36_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-37/config.template.json
+++ b/deployment/aws/instance-37/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S37N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S37N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S37N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S37N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S37N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S37N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U37",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE37_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-38/config.template.json
+++ b/deployment/aws/instance-38/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S38N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S38N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S38N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S38N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S38N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S38N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U38",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE38_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-39/config.template.json
+++ b/deployment/aws/instance-39/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S39N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S39N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S39N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S39N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S39N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S39N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U39",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE39_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-4/config.template.json
+++ b/deployment/aws/instance-4/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S4N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S4N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S4N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S4N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S4N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S4N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U4",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE4_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-40/config.template.json
+++ b/deployment/aws/instance-40/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S40N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S40N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S40N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S40N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S40N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S40N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U40",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE40_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-41/config.template.json
+++ b/deployment/aws/instance-41/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S41N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S41N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S41N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S41N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S41N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S41N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U41",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE41_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-42/config.template.json
+++ b/deployment/aws/instance-42/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S42N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S42N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S42N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S42N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S42N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S42N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U42",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE42_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-43/config.template.json
+++ b/deployment/aws/instance-43/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S43N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S43N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S43N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S43N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S43N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S43N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U43",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE43_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-44/config.template.json
+++ b/deployment/aws/instance-44/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S44N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S44N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S44N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S44N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S44N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S44N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U44",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE44_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-45/config.template.json
+++ b/deployment/aws/instance-45/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S45N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S45N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S45N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S45N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S45N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S45N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U45",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE45_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-46/config.template.json
+++ b/deployment/aws/instance-46/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S46N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S46N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S46N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S46N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S46N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S46N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U46",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE46_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-47/config.template.json
+++ b/deployment/aws/instance-47/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S47N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S47N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S47N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S47N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S47N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S47N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U47",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE47_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-48/config.template.json
+++ b/deployment/aws/instance-48/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S48N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S48N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S48N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S48N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S48N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S48N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U48",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE48_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-49/config.template.json
+++ b/deployment/aws/instance-49/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S49N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S49N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S49N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S49N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S49N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S49N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U49",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE49_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-5/config.template.json
+++ b/deployment/aws/instance-5/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S5N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S5N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S5N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S5N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S5N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S5N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U5",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE5_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-50/config.template.json
+++ b/deployment/aws/instance-50/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S50N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE49_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S50N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE49_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S50N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE49_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S50N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE49_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S50N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE49_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S50N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE49_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U50",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE50_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-6/config.template.json
+++ b/deployment/aws/instance-6/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S6N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S6N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S6N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S6N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S6N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S6N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U6",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE6_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-7/config.template.json
+++ b/deployment/aws/instance-7/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S7N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S7N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S7N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S7N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S7N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S7N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U7",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE7_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-8/config.template.json
+++ b/deployment/aws/instance-8/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S8N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S8N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S8N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S8N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S8N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S8N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U8",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE8_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }

--- a/deployment/aws/instance-9/config.template.json
+++ b/deployment/aws/instance-9/config.template.json
@@ -11,7 +11,7 @@
       "host": "0.0.0.0",
       "port": 62000,
       "storage_kb": 8192,
-      "bootstrap": "none",
+      "bootstrap": "${INSTANCE1_IP}:62000",
       "peers": [
         {
           "node_id": "S9N2",
@@ -570,7 +570,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S9N3",
@@ -852,7 +853,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S9N4",
@@ -1134,7 +1136,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S9N5",
@@ -1416,7 +1419,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S9N6",
@@ -1698,7 +1702,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     },
     {
       "node_id": "S9N7",
@@ -1980,7 +1985,8 @@
           "host": "${INSTANCE50_IP}",
           "port": 62000
         }
-      ]
+      ],
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ],
   "users": [
@@ -1988,7 +1994,7 @@
       "user_id": "U9",
       "host": "0.0.0.0",
       "port": 62100,
-      "bootstrap": "${INSTANCE9_IP}:62000"
+      "bootstrap": "${INSTANCE1_IP}:62000"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- point every AWS instance configuration template to the S1N1 node as the sole bootstrap endpoint
- update user bootstrap settings to reuse the shared S1N1 address

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e753c8618c83278dbef8fc7acf7e2a