### PR TITLE
Add Nova folding rollback for chain reorganizations

### DIFF
--- a/src/p2p/node.rs
+++ b/src/p2p/node.rs
@@ -2021,6 +2021,10 @@ impl Node {
 
         self.stop_mining_thread();
 
+        if is_reorg {
+            self.storage_manager.rollback_to_height(prefix_len);
+        }
+
         while self.chain.blocks.len() > prefix_len {
             self.chain.blocks.pop();
         }


### PR DESCRIPTION
## Summary
- track per-file Nova round history so folding cycles can be rebuilt when earlier blocks are dropped
- implement rollback logic in the storage manager and invoke it when the node switches to a shorter branch

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e9de4ce8408327bb1f76fe5177237c