### PR TITLE
Align CLI node gossip behaviour with simulator defaults

### DIFF
--- a/src/p2p/user_node.rs
+++ b/src/p2p/user_node.rs
@@ -90,6 +90,7 @@ pub struct UserNode {
     active_requests: Arc<Mutex<HashSet<String>>>,
     stored_files: Arc<Mutex<HashMap<String, StoredFileRecord>>>,
     broadcast_buffer: Arc<Mutex<VecDeque<CommandRequest>>>,
+    known_peers: Arc<Mutex<HashSet<SocketAddr>>>,
     force_bootstrap_target: bool,
 }
 
@@ -119,6 +120,7 @@ impl UserNode {
             active_requests: Arc::new(Mutex::new(HashSet::new())),
             stored_files: Arc::new(Mutex::new(HashMap::new())),
             broadcast_buffer: Arc::new(Mutex::new(VecDeque::new())),
+            known_peers: Arc::new(Mutex::new(HashSet::new())),
             force_bootstrap_target,
         }
     }
@@ -210,6 +212,9 @@ impl UserNode {
                     }
                 }
             }
+        }
+        if !addrs.is_empty() {
+            self.remember_peers(&addrs);
         }
         addrs
     }
@@ -840,12 +845,20 @@ impl UserNode {
                 "storage_rounds": storage_rounds,
             }
         });
-        let mut targets = self.fetch_peer_targets();
-        targets.retain(|addr| *addr != self.bootstrap_addr);
+        let mut targets = self.collect_known_peers();
+        if targets.is_empty() {
+            targets = self.fetch_peer_targets();
+        }
+        if targets.is_empty() {
+            targets.push(self.bootstrap_addr);
+        }
         targets.shuffle(&mut rand::thread_rng());
         let max_targets = std::cmp::max(1, Self::MAX_STORAGE_BROADCAST_TARGETS);
         let mut selected: Vec<SocketAddr> = targets.into_iter().take(max_targets).collect();
         self.ensure_bootstrap_target(&mut selected, max_targets);
+        if selected.is_empty() {
+            selected.push(self.bootstrap_addr);
+        }
         for target in selected {
             let _ = super::node::send_json_line_without_response(target, &offer);
         }
@@ -929,6 +942,9 @@ impl UserNode {
                     .iter()
                     .map(|assignment| assignment.addr)
                     .collect();
+                if !addrs.is_empty() {
+                    self.remember_peers(&addrs);
+                }
                 log_msg(
                     "SUCCESS",
                     "USER_NODE",
@@ -1028,6 +1044,21 @@ impl UserNode {
 }
 
 impl UserNode {
+    fn collect_known_peers(&self) -> Vec<SocketAddr> {
+        let peers = self.known_peers.lock();
+        peers.iter().copied().collect()
+    }
+
+    fn remember_peers(&self, peers: &[SocketAddr]) {
+        if peers.is_empty() {
+            return;
+        }
+        let mut known = self.known_peers.lock();
+        for addr in peers {
+            known.insert(*addr);
+        }
+    }
+
     fn ensure_bootstrap_target(&self, selected: &mut Vec<SocketAddr>, max_targets: usize) {
         if !self.force_bootstrap_target {
             return;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
 use std::process::{Child, Command};
@@ -226,6 +227,7 @@ pub fn run_deployment(config: DeploymentConfig) -> Result<(), DeploymentConfigEr
 
     let mut children: Vec<(String, Child)> = Vec::new();
     let mut node_stagger_rng = rand::thread_rng();
+    let static_peer_map = assemble_static_peer_map(&config);
     for (idx, node_cfg) in config.nodes.iter().enumerate() {
         let chunk_size = node_cfg.chunk_size.unwrap_or(sim_config.chunk_size);
         let storage_kb = node_cfg.storage_kb.unwrap_or(default_storage_kb);
@@ -272,7 +274,13 @@ pub fn run_deployment(config: DeploymentConfig) -> Result<(), DeploymentConfigEr
             .arg(bobtail_k.to_string())
             .env("P2P_SIM_CONFIG", config_json.clone());
         cmd.env_remove("BPST_STATIC_PEERS");
-        if !node_cfg.peers.is_empty() {
+        if let Some(static_peers) = static_peer_map.get(&node_cfg.node_id) {
+            if !static_peers.is_empty() {
+                let peers_json =
+                    serde_json::to_string(static_peers).expect("无法序列化静态对等节点配置");
+                cmd.env("BPST_STATIC_PEERS", peers_json);
+            }
+        } else if !node_cfg.peers.is_empty() {
             let peers_json =
                 serde_json::to_string(&node_cfg.peers).expect("无法序列化静态对等节点配置");
             cmd.env("BPST_STATIC_PEERS", peers_json);
@@ -516,6 +524,37 @@ fn normalize_difficulty_hex(raw: &str) -> Result<String, DeploymentConfigError> 
         })
 }
 
+fn assemble_static_peer_map(config: &DeploymentConfig) -> HashMap<String, Vec<PeerConfig>> {
+    let mut known_nodes: HashMap<String, (String, u16)> = HashMap::new();
+    for node in &config.nodes {
+        known_nodes.insert(node.node_id.clone(), (node.host.clone(), node.port));
+    }
+
+    let mut static_map: HashMap<String, Vec<PeerConfig>> = HashMap::new();
+    for node in &config.nodes {
+        let mut combined: HashMap<String, PeerConfig> = HashMap::new();
+
+        for (other_id, (host, port)) in &known_nodes {
+            if other_id == &node.node_id {
+                continue;
+            }
+            combined.entry(other_id.clone()).or_insert(PeerConfig {
+                node_id: other_id.clone(),
+                host: host.clone(),
+                port: *port,
+            });
+        }
+
+        for peer in &node.peers {
+            combined.insert(peer.node_id.clone(), peer.clone());
+        }
+
+        static_map.insert(node.node_id.clone(), combined.into_values().collect());
+    }
+
+    static_map
+}
+
 fn sleep_with_stagger<R>(index: usize, rng: &mut R)
 where
     R: Rng + ?Sized,
@@ -601,7 +640,7 @@ fn should_force_bootstrap_gossip() -> bool {
                 !matches!(normalized.as_str(), "0" | "false" | "no")
             }
         }
-        Err(_) => true,
+        Err(_) => false,
     }
 }
 


### PR DESCRIPTION
## Summary
- precompute per-node static peer manifests during deployments so subcommand launches inherit the simulator gossip seeding behaviour
- let user nodes launched via subcommands cache discovered peer addresses and reuse them for gossip-based storage offers instead of repeatedly querying specific nodes
- make forced bootstrap targeting opt-in via environment variables to match the simulator defaults

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68ec90305f848327b9872eee4601661d