### PR TITLE
Add performance monitoring for dPDP and folding workflows

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,1 +1,2 @@
 pub mod datastructures;
+pub mod perf_monitor;

--- a/src/common/perf_monitor.rs
+++ b/src/common/perf_monitor.rs
@@ -1,0 +1,330 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+struct PerfKey {
+    node_id: Option<String>,
+    user_id: Option<String>,
+    operation_segments: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct PerfStats {
+    calls: u64,
+    total_duration: Duration,
+    total_cycles: u128,
+    cycle_samples: u64,
+}
+
+impl PerfStats {
+    fn record(&mut self, duration: Duration, cycles: Option<u64>) {
+        self.calls = self.calls.saturating_add(1);
+        self.total_duration += duration;
+        if let Some(value) = cycles {
+            self.total_cycles = self.total_cycles.saturating_add(value as u128);
+            self.cycle_samples = self.cycle_samples.saturating_add(1);
+        }
+    }
+}
+
+/// 聚合后的性能记录行。
+#[derive(Clone, Debug)]
+pub struct PerfReportRow {
+    pub node_id: Option<String>,
+    pub user_id: Option<String>,
+    pub operation_segments: Vec<String>,
+    pub calls: u64,
+    pub total_duration: Duration,
+    pub total_cycles: u128,
+    pub cycle_samples: u64,
+}
+
+impl PerfReportRow {
+    /// 返回 `op1::op2::op3` 风格的操作路径。
+    pub fn operation_path(&self) -> String {
+        self.operation_segments.join("::")
+    }
+}
+
+/// 性能监控器，负责记录和导出 dPDP / Nova 折叠相关操作的性能数据。
+pub struct PerformanceMonitor {
+    inner: Mutex<HashMap<PerfKey, PerfStats>>,
+}
+
+static GLOBAL_MONITOR: Lazy<PerformanceMonitor> = Lazy::new(PerformanceMonitor::new);
+
+impl PerformanceMonitor {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// 全局唯一的性能监控器实例。
+    pub fn global() -> &'static Self {
+        &GLOBAL_MONITOR
+    }
+
+    /// 进入一个性能监控作用域，返回 RAII guard。
+    pub fn enter(
+        &'static self,
+        node_id: Option<&str>,
+        user_id: Option<&str>,
+        segments: &[&str],
+    ) -> PerfGuard {
+        let key = PerfKey {
+            node_id: node_id.map(|id| id.to_string()),
+            user_id: user_id.map(|id| id.to_string()),
+            operation_segments: segments.iter().map(|s| s.to_string()).collect(),
+        };
+        PerfGuard::new(self, key)
+    }
+
+    fn enter_with_key(&'static self, key: PerfKey) -> PerfGuard {
+        PerfGuard::new(self, key)
+    }
+
+    fn record_observation(&self, key: PerfKey, duration: Duration, cycles: Option<u64>) {
+        let mut inner = self.inner.lock();
+        let stats = inner.entry(key).or_default();
+        stats.record(duration, cycles);
+    }
+
+    /// 生成当前的快照数据。
+    pub fn snapshot(&self) -> Vec<PerfReportRow> {
+        let mut rows: Vec<_> = self
+            .inner
+            .lock()
+            .iter()
+            .map(|(key, stats)| PerfReportRow {
+                node_id: key.node_id.clone(),
+                user_id: key.user_id.clone(),
+                operation_segments: key.operation_segments.clone(),
+                calls: stats.calls,
+                total_duration: stats.total_duration,
+                total_cycles: stats.total_cycles,
+                cycle_samples: stats.cycle_samples,
+            })
+            .collect();
+        rows.sort_by(|a, b| compare_rows(a, b));
+        rows
+    }
+
+    /// 清空已有的监控数据。
+    pub fn clear(&self) {
+        self.inner.lock().clear();
+    }
+
+    /// 将快照写出为 CSV。
+    pub fn write_csv<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        writeln!(
+            writer,
+            "node_id,user_id,operation_path,calls,total_micros,avg_micros,total_cycles,avg_cycles"
+        )?;
+        for row in self.snapshot() {
+            let total_micros = row.total_duration.as_micros();
+            let avg_micros = if row.calls > 0 {
+                total_micros / row.calls as u128
+            } else {
+                0
+            };
+            let (total_cycles, avg_cycles) = if row.cycle_samples > 0 {
+                let avg = row.total_cycles / row.cycle_samples as u128;
+                (row.total_cycles.to_string(), avg.to_string())
+            } else {
+                (String::new(), String::new())
+            };
+            writeln!(
+                writer,
+                "{},{},{},{},{},{},{},{}",
+                row.node_id.as_deref().unwrap_or(""),
+                row.user_id.as_deref().unwrap_or(""),
+                row.operation_path(),
+                row.calls,
+                total_micros,
+                avg_micros,
+                total_cycles,
+                avg_cycles
+            )?;
+        }
+        Ok(())
+    }
+
+    /// 按照 FlameGraph collapsed stack 的格式导出时长和 cycles。
+    pub fn write_collapsed_flamegraph<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        for row in self.snapshot() {
+            let mut stack = Vec::new();
+            if let Some(node) = &row.node_id {
+                stack.push(format!("node:{}", node));
+            }
+            if let Some(user) = &row.user_id {
+                stack.push(format!("user:{}", user));
+            }
+            stack.extend(row.operation_segments.iter().cloned());
+            let frame = stack.join(";");
+            let duration_value = row.total_duration.as_micros();
+            if duration_value > 0 {
+                writeln!(writer, "{} {}", frame, duration_value)?;
+            }
+            if row.cycle_samples > 0 && row.total_cycles > 0 {
+                let mut cycle_stack = stack.clone();
+                cycle_stack.push(String::from("[cycles]"));
+                writeln!(writer, "{} {}", cycle_stack.join(";"), row.total_cycles)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// 保存 CSV 报告到文件。
+    pub fn save_csv<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        let mut file = File::create(path)?;
+        self.write_csv(&mut file)?;
+        Ok(path.to_path_buf())
+    }
+
+    /// 保存 collapsed stack 报告到文件。
+    pub fn save_collapsed_flamegraph<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        let mut file = File::create(path)?;
+        self.write_collapsed_flamegraph(&mut file)?;
+        Ok(path.to_path_buf())
+    }
+
+    /// 同时保存 CSV 与 FlameGraph 两种格式，返回文件路径。
+    pub fn save_reports<P: AsRef<Path>>(
+        &self,
+        dir: P,
+        prefix: &str,
+    ) -> io::Result<(PathBuf, PathBuf)> {
+        let sanitized = sanitize_prefix(prefix);
+        let dir = dir.as_ref();
+        std::fs::create_dir_all(dir)?;
+        let csv_path = dir.join(format!("{}_performance.csv", sanitized));
+        let flame_path = dir.join(format!("{}_performance.collapsed", sanitized));
+        let csv = self.save_csv(csv_path)?;
+        let flame = self.save_collapsed_flamegraph(flame_path)?;
+        Ok((csv, flame))
+    }
+}
+
+fn compare_rows(a: &PerfReportRow, b: &PerfReportRow) -> Ordering {
+    let node_cmp = a
+        .node_id
+        .as_deref()
+        .unwrap_or("")
+        .cmp(b.node_id.as_deref().unwrap_or(""));
+    if node_cmp != Ordering::Equal {
+        return node_cmp;
+    }
+    let user_cmp = a
+        .user_id
+        .as_deref()
+        .unwrap_or("")
+        .cmp(b.user_id.as_deref().unwrap_or(""));
+    if user_cmp != Ordering::Equal {
+        return user_cmp;
+    }
+    a.operation_segments.cmp(&b.operation_segments)
+}
+
+fn sanitize_prefix(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+fn read_cpu_cycles() -> Option<u64> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: _rdtsc 只读取时间戳计数器，不会产生未定义行为。
+        Some(unsafe { core::arch::x86_64::_rdtsc() })
+    }
+    #[cfg(target_arch = "x86")]
+    {
+        // SAFETY: _rdtsc 只读取时间戳计数器，不会产生未定义行为。
+        Some(unsafe { core::arch::x86::_rdtsc() as u64 })
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        None
+    }
+}
+
+/// RAII guard，用于在作用域结束时记录性能数据。
+pub struct PerfGuard {
+    monitor: &'static PerformanceMonitor,
+    key: PerfKey,
+    start: Instant,
+    start_cycles: Option<u64>,
+    active: bool,
+}
+
+impl PerfGuard {
+    fn new(monitor: &'static PerformanceMonitor, key: PerfKey) -> Self {
+        Self {
+            monitor,
+            key,
+            start: Instant::now(),
+            start_cycles: read_cpu_cycles(),
+            active: true,
+        }
+    }
+
+    /// 从当前 guard 派生子操作，沿用节点/用户上下文并追加路径。
+    pub fn child(&self, segments: &[&str]) -> PerfGuard {
+        let mut combined = self.key.operation_segments.clone();
+        combined.extend(segments.iter().map(|s| s.to_string()));
+        let child_key = PerfKey {
+            node_id: self.key.node_id.clone(),
+            user_id: self.key.user_id.clone(),
+            operation_segments: combined,
+        };
+        self.monitor.enter_with_key(child_key)
+    }
+
+    /// 主动终止记录，用于异常路径。
+    pub fn cancel(mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for PerfGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let duration = self.start.elapsed();
+        let cycles = self
+            .start_cycles
+            .and_then(|start| read_cpu_cycles().map(|end| end.wrapping_sub(start)));
+        self.monitor
+            .record_observation(self.key.clone(), duration, cycles);
+    }
+}
+
+/// 简化函数，直接基于全局监控器进入一个性能作用域。
+pub fn perf_scope(node_id: Option<&str>, user_id: Option<&str>, segments: &[&str]) -> PerfGuard {
+    PerformanceMonitor::global().enter(node_id, user_id, segments)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,13 +58,13 @@ fn main() {
     // 如果没有子命令，则运行P2P模拟
     // 定义 P2P 模拟的配置
     let config = P2PSimConfig {
-        num_nodes: 10,            // 节点数量
+        num_nodes: 10,           // 节点数量
         num_file_owners: 2,      // 文件所有者数量
         sim_duration_sec: 90000, // 模拟持续时间（秒）
         chunk_size: 64,          // 数据块大小
         min_file_kb: 1,          // 最小文件大小 (KB)
         max_file_kb: 1,          // 最大文件大小 (KB)
-        min_storage_nodes: 5 ,    // 最小存储节点数
+        min_storage_nodes: 5,    // 最小存储节点数
         max_storage_nodes: 9,    // 最大存储节点数
         base_port: 62000,        // 基础端口号
         bobtail_k: 3,            // Bobtail 参数 K

--- a/src/p2p/node.rs
+++ b/src/p2p/node.rs
@@ -28,6 +28,7 @@ use once_cell::sync::Lazy;
 use crate::common::datastructures::{
     Block, BlockBody, BobtailProof, ChallengeEntry, DPDPParams, DPDPProof, FileChunk, ProofSummary,
 }; // 数据结构
+use crate::common::perf_monitor::perf_scope;
 use crate::consensus::blockchain::Blockchain; // 区块链逻辑
 use crate::crypto::deserialize_g2; // G2点反序列化工具
 use crate::crypto::dpdp::DPDP; // dPDP 密码学逻辑
@@ -2239,7 +2240,15 @@ impl Node {
                             }
                         };
 
-                        if !DPDP::check_proof(&params, &proof, &challenge) {
+                        let proof_valid = {
+                            let _guard = perf_scope(
+                                Some(self.node_id.as_str()),
+                                None,
+                                &["dPDP", "verify", "check_proof"],
+                            );
+                            DPDP::check_proof(&params, &proof, &challenge)
+                        };
+                        if !proof_valid {
                             log_msg(
                                 "CRITICAL",
                                 "CONSENSUS",

--- a/src/roles/file_owner.rs
+++ b/src/roles/file_owner.rs
@@ -3,6 +3,7 @@ use rand::{Rng, RngCore};
 
 // 导入项目内的数据结构和密码学模块
 use crate::common::datastructures::{DPDPParams, DPDPTags, FileChunk};
+use crate::common::perf_monitor::perf_scope;
 use crate::crypto::dpdp::DPDP;
 use crate::utils::log_msg;
 
@@ -33,7 +34,10 @@ impl FileOwner {
     /// 创建一个新的 FileOwner 实例
     pub fn new(owner_id: String, chunk_size: usize) -> Self {
         // 1. 生成 dPDP 密钥对
-        let params = DPDP::key_gen();
+        let params = {
+            let _guard = perf_scope(None, Some(owner_id.as_str()), &["dPDP", "key_gen"]);
+            DPDP::key_gen()
+        };
         // 2. 初始化一个空的标签集合
         let tags = DPDPTags { tags: Vec::new() };
         // 3. 创建一个唯一的 file_id
@@ -72,7 +76,10 @@ impl FileOwner {
         // 1. 将文件字节流分割成原始数据块
         let raw_chunks = self.split_file(file_bytes);
         // 2. 使用 dPDP 私钥为所有数据块生成对应的标签
-        let tags = DPDP::tag_file(&self.params, &raw_chunks);
+        let tags = {
+            let _guard = perf_scope(None, Some(self.owner_id.as_str()), &["dPDP", "tag_file"]);
+            DPDP::tag_file(&self.params, &raw_chunks)
+        };
         // 3. 将原始数据块和生成的标签打包成 FileChunk 结构体
         let chunks: Vec<FileChunk> = raw_chunks
             .into_iter()

--- a/src/roles/prover.rs
+++ b/src/roles/prover.rs
@@ -6,6 +6,7 @@ use num_bigint::BigUint;
 
 // 导入项目内的数据结构和密码学模块
 use crate::common::datastructures::{DPDPProof, DPDPTags};
+use crate::common::perf_monitor::perf_scope;
 use crate::crypto::dpdp::DPDP;
 use crate::utils::log_msg;
 
@@ -54,14 +55,35 @@ impl Prover {
         challenge_size: Option<usize>,
     ) -> (DPDPProof, ChallengeVector, ContributionVector) {
         // 1. 根据上下文（前一个块哈希、时间戳）和文件标签生成一个确定性的随机挑战
-        let challenge = DPDP::gen_chal(prev_hash, timestamp, file_tags, challenge_size);
+        let challenge = {
+            let _guard = perf_scope(
+                Some(self.node_id.as_str()),
+                None,
+                &["dPDP", "prove", "gen_chal"],
+            );
+            DPDP::gen_chal(prev_hash, timestamp, file_tags, challenge_size)
+        };
 
         // 2. 使用文件块、标签和挑战来生成聚合的 dPDP 证明
-        let proof = DPDP::gen_proof(file_tags, file_chunks, &challenge);
+        let proof = {
+            let _guard = perf_scope(
+                Some(self.node_id.as_str()),
+                None,
+                &["dPDP", "prove", "gen_proof"],
+            );
+            DPDP::gen_proof(file_tags, file_chunks, &challenge)
+        };
 
         // 3. 生成用于更新文件状态的“贡献值”
         // 这些值是证明过程的副产品，但对于维护文件的版本和状态至关重要
-        let contributions = DPDP::gen_contributions(file_tags, file_chunks, &challenge);
+        let contributions = {
+            let _guard = perf_scope(
+                Some(self.node_id.as_str()),
+                None,
+                &["dPDP", "prove", "gen_contributions"],
+            );
+            DPDP::gen_contributions(file_tags, file_chunks, &challenge)
+        };
 
         log_msg(
             "DEBUG",

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -8,6 +9,7 @@ use std::time::{Duration, Instant};
 use crossbeam_channel::unbounded;
 use rand::Rng;
 
+use crate::common::perf_monitor::PerformanceMonitor;
 use crate::config::{
     DeploymentConfig, DeploymentConfigError, NodeDeployment, P2PSimConfig, PeerConfig,
 };
@@ -619,7 +621,9 @@ where
     } else {
         NodeType::Storage
     };
-    let node = Box::new(Node::new(
+    let node_label = node_id.clone();
+    let perf_dir = std::env::var_os("BPST_PERF_DIR").map(PathBuf::from);
+    let node = Node::new(
         node_id,
         listen_host,
         advertise_host,
@@ -632,8 +636,34 @@ where
         bobtail_k,
         difficulty_override,
         report_tx,
-    ));
+    );
     node.run();
+    if let Some(dir) = perf_dir {
+        let prefix = format!("node-{}", node_label);
+        match PerformanceMonitor::global().save_reports(&dir, &prefix) {
+            Ok((csv, flame)) => {
+                log_msg(
+                    "INFO",
+                    "PERF",
+                    Some(node_label.clone()),
+                    &format!(
+                        "节点 {} 的性能报告已生成：{} 与 {}",
+                        node_label,
+                        csv.display(),
+                        flame.display()
+                    ),
+                );
+            }
+            Err(err) => {
+                log_msg(
+                    "ERROR",
+                    "PERF",
+                    Some(node_label.clone()),
+                    &format!("节点 {} 写入性能报告失败: {err}", node_label),
+                );
+            }
+        }
+    }
 }
 
 pub fn run_user_process_from_args<I>(mut args: I)
@@ -659,15 +689,36 @@ where
     // ----------------
 
     let owner = FileOwner::new(owner_id, config.chunk_size);
-    let user = Box::new(UserNode::new(
-        owner,
-        host,
-        advertise_host,
-        port,
-        bootstrap,
-        config.clone(),
-    ));
+    let owner_label = owner.owner_id.clone();
+    let perf_dir = std::env::var_os("BPST_PERF_DIR").map(PathBuf::from);
+    let user = UserNode::new(owner, host, advertise_host, port, bootstrap, config.clone());
     user.run();
+    if let Some(dir) = perf_dir {
+        let prefix = format!("user-{}", owner_label);
+        match PerformanceMonitor::global().save_reports(&dir, &prefix) {
+            Ok((csv, flame)) => {
+                log_msg(
+                    "INFO",
+                    "PERF",
+                    Some(owner_label.clone()),
+                    &format!(
+                        "用户 {} 的性能报告已生成：{} 与 {}",
+                        owner_label,
+                        csv.display(),
+                        flame.display()
+                    ),
+                );
+            }
+            Err(err) => {
+                log_msg(
+                    "ERROR",
+                    "PERF",
+                    Some(owner_label.clone()),
+                    &format!("用户 {} 写入性能报告失败: {err}", owner_label),
+                );
+            }
+        }
+    }
 }
 
 pub fn run_observer_process_from_args<I>(mut args: I)

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -7,6 +7,7 @@ use num_bigint::BigUint;
 use parking_lot::Mutex;
 
 use crate::common::datastructures::{Block, DPDPParams, DPDPProof, DPDPTags, FileChunk};
+use crate::common::perf_monitor::perf_scope;
 use crate::crypto::deserialize_g2;
 use crate::crypto::folding::{
     block_validation_relaxed_r1cs, dpdp_verification_relaxed_r1cs, fr_to_padded_hex,
@@ -588,7 +589,14 @@ impl StorageManager {
             sk_alpha: BigUint::from(0u32),
         };
 
-        let (dpdp_circuit, valid) = dpdp_verification_relaxed_r1cs(&params, proof, challenge);
+        let (dpdp_circuit, valid) = {
+            let _guard = perf_scope(
+                Some(self.node_id.as_str()),
+                None,
+                &["Folding", "dpdp_verification"],
+            );
+            dpdp_verification_relaxed_r1cs(&params, proof, challenge)
+        };
         if !valid {
             crate::utils::log_msg(
                 "ERROR",
@@ -599,9 +607,22 @@ impl StorageManager {
             return None;
         }
 
-        let block_circuit = block_validation_relaxed_r1cs(block, &block.prev_hash, block.height);
-        let state_circuit =
-            state_update_relaxed_r1cs(&before_state, &[(file_id.to_string(), claimed_root)]);
+        let block_circuit = {
+            let _guard = perf_scope(
+                Some(self.node_id.as_str()),
+                None,
+                &["Folding", "block_validation"],
+            );
+            block_validation_relaxed_r1cs(block, &block.prev_hash, block.height)
+        };
+        let state_circuit = {
+            let _guard = perf_scope(
+                Some(self.node_id.as_str()),
+                None,
+                &["Folding", "state_update"],
+            );
+            state_update_relaxed_r1cs(&before_state, &[(file_id.to_string(), claimed_root)])
+        };
 
         let result = {
             let cycle = inner.file_cycles.get_mut(file_id)?;
@@ -613,7 +634,15 @@ impl StorageManager {
                 &format!("准备吸收文件 {} 的第 {} 个折叠轮次。", file_id, next_step),
             );
             let circuits = vec![dpdp_circuit, block_circuit, state_circuit];
-            let result = match cycle.nova.absorb_round(circuits.clone()) {
+            let absorb_result = {
+                let _guard = perf_scope(
+                    Some(self.node_id.as_str()),
+                    None,
+                    &["Folding", "absorb_round"],
+                );
+                cycle.nova.absorb_round(circuits.clone())
+            };
+            let result = match absorb_result {
                 Ok(res) => res,
                 Err(NovaFoldingError::CycleComplete) => return None,
                 Err(err) => {
@@ -653,7 +682,12 @@ impl StorageManager {
                     Some(self.node_id.clone()),
                     &format!("文件 {} 达到存储周期阈值，尝试生成最终折叠证明。", file_id),
                 );
-                match cycle.nova.finalize() {
+                let finalize_result = {
+                    let _guard =
+                        perf_scope(Some(self.node_id.as_str()), None, &["Folding", "finalize"]);
+                    cycle.nova.finalize()
+                };
+                match finalize_result {
                     Ok(Some(final_proof)) => cycle.set_final_artifact(final_proof),
                     Ok(None) | Err(NovaFoldingError::CycleComplete) => {}
                     Err(err) => {


### PR DESCRIPTION
## Summary
- introduce a global performance monitor that records per-node/user timings and CPU cycles and exports CSV and flamegraph data
- instrument dPDP proof generation/verification and Nova folding steps with scoped guards to capture fine-grained metrics
- allow node and user processes to dump performance reports automatically when `BPST_PERF_DIR` is configured

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f8860a12a48327bdd9e2e8508af7da