### PR TITLE
Add performance monitoring for dPDP and Nova folding operations

### DIFF
--- a/src/crypto/dpdp.rs
+++ b/src/crypto/dpdp.rs
@@ -11,6 +11,7 @@ use crate::common::datastructures::{DPDPParams, DPDPProof, DPDPTags};
 use crate::crypto::folding::{dpdp_verification_relaxed_r1cs, RelaxedR1CS};
 use crate::crypto::{curve_order, deserialize_g1, serialize_g1};
 use crate::merkle::MerkleTree;
+use crate::monitoring::perf;
 use crate::utils::{hash_to_field, sha256_hex};
 
 /// Merkle 证明路径，按从叶子到根的顺序存储相邻节点及其方向。
@@ -88,6 +89,7 @@ pub struct DPDPVerificationOutput {
 impl DPDP {
     /// 生成 dPDP 公私钥参数。
     pub fn key_gen() -> DPDPParams {
+        let _span = perf::span(["dPDP", "key_gen"]);
         let sk_alpha = random_scalar();
         let g: G2Projective = G2Affine::generator().into();
         let u: G1Projective = G1Affine::generator().into();
@@ -103,9 +105,12 @@ impl DPDP {
 
     /// 使用 dPDP 私钥为文件块生成标签。
     pub fn tag_file(params: &DPDPParams, file_chunks: &[Vec<u8>]) -> DPDPTags {
+        let span = perf::span(["dPDP", "tag_file"]);
         let mut tags_bytes = Vec::with_capacity(file_chunks.len());
         let sk_fr = biguint_to_fr(&params.sk_alpha);
         for (i, chunk) in file_chunks.iter().enumerate() {
+            let chunk_label = format!("chunk_{}", i);
+            let _chunk_span = span.child(vec![String::from("chunk"), chunk_label]);
             let mut b_i = chunk_to_int(chunk);
             let order = curve_order();
             b_i %= &order;
@@ -125,6 +130,7 @@ impl DPDP {
         tags: &DPDPTags,
         m: Option<usize>,
     ) -> Vec<(usize, BigUint)> {
+        let span = perf::span(["dPDP", "gen_chal"]);
         if tags.is_empty() {
             return Vec::new();
         }
@@ -142,6 +148,7 @@ impl DPDP {
         let order = curve_order();
         let mut challenges = Vec::new();
         for j in 0..count {
+            let _round_span = span.child(vec![String::from("entry"), format!("index_{}", j)]);
             let seed = format!("{}:{}:{}", prev_hash, timestamp, j);
             let idx = (hash_to_field(seed.as_bytes()) % n.to_biguint().unwrap())
                 .to_usize()
@@ -160,9 +167,12 @@ impl DPDP {
         file_chunks: &HashMap<usize, Vec<u8>>,
         challenge: &[(usize, BigUint)],
     ) -> Vec<(usize, BigUint, Vec<u8>)> {
+        let span = perf::span(["dPDP", "gen_contributions"]);
         let order = curve_order();
         let mut contributions = Vec::new();
         for (i, v_i) in challenge {
+            let _chunk_span =
+                span.child(vec![String::from("contribution"), format!("chunk_{}", i)]);
             let chunk = file_chunks
                 .get(i)
                 .expect("missing chunk for challenge index");
@@ -183,10 +193,12 @@ impl DPDP {
         file_chunks: &HashMap<usize, Vec<u8>>,
         challenge: &[(usize, BigUint)],
     ) -> DPDPProof {
+        let span = perf::span(["dPDP", "gen_proof"]);
         let order = curve_order();
         let mut agg_mu = BigUint::from(0u32);
         let mut agg_sigma = G1Projective::zero();
         for (i, v_i) in challenge {
+            let _chunk_span = span.child(vec![String::from("aggregate"), format!("chunk_{}", i)]);
             let chunk = file_chunks.get(i).expect("missing chunk");
             let mut b_i = chunk_to_int(chunk);
             b_i %= &order;
@@ -207,6 +219,7 @@ impl DPDP {
         proof: &DPDPProof,
         challenge: &[(usize, BigUint)],
     ) -> bool {
+        let _span = perf::span(["dPDP", "check_proof"]);
         Self::check_proof_with_relaxed(params, proof, challenge).valid
     }
 
@@ -216,16 +229,23 @@ impl DPDP {
         proof: &DPDPProof,
         challenge: &[(usize, BigUint)],
     ) -> DPDPVerificationOutput {
+        let span = perf::span(["dPDP", "check_with_relaxed"]);
         let sigma = deserialize_g1(&proof.sigma);
         if sigma.is_zero() {
-            let (circuit, _) = dpdp_verification_relaxed_r1cs(params, proof, challenge);
+            let (circuit, _) = {
+                let _relaxed_span = span.child(vec![String::from("relaxed_r1cs")]);
+                dpdp_verification_relaxed_r1cs(params, proof, challenge)
+            };
             return DPDPVerificationOutput {
                 valid: challenge.is_empty(),
                 circuit,
             };
         }
 
-        let (circuit, valid) = dpdp_verification_relaxed_r1cs(params, proof, challenge);
+        let (circuit, valid) = {
+            let _relaxed_span = span.child(vec![String::from("relaxed_r1cs")]);
+            dpdp_verification_relaxed_r1cs(params, proof, challenge)
+        };
         DPDPVerificationOutput { valid, circuit }
     }
 
@@ -237,12 +257,15 @@ impl DPDP {
         challenged_data: &ChallengedChunkData,
         merkle_root: &str,
     ) -> bool {
+        let span = perf::span(["dPDP", "verify_with_merkle"]);
         let order = curve_order();
         let mut recomputed_mu = BigUint::from(0u32);
         if challenge.len() != challenged_data.len() {
             return false;
         }
         for (i, v_i) in challenge {
+            let _challenge_span =
+                span.child(vec![String::from("verify_entry"), format!("chunk_{}", i)]);
             let Some((chunk, proof_path)) = challenged_data.get(i) else {
                 return false;
             };

--- a/src/crypto/folding.rs
+++ b/src/crypto/folding.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 use crate::common::datastructures::{Block, DPDPParams, DPDPProof};
 use crate::crypto::deserialize_g1;
 use crate::crypto::dpdp::hash_to_g1;
+use crate::monitoring::perf;
 use crate::storage::state::StorageStateTree;
 use crate::utils::{h_join, log_msg};
 
@@ -935,6 +936,7 @@ impl NovaFoldingCycle {
         &mut self,
         circuits: Vec<RelaxedR1CS<Fr>>,
     ) -> Result<NovaRoundResult, NovaFoldingError> {
+        let span = perf::span(["Nova", "absorb_round"]);
         if circuits.is_empty() {
             log_msg("WARN", "NOVA", None, "尝试吸收折叠轮次时电路集合为空。");
             return Err(NovaFoldingError::EmptyRound);
@@ -978,19 +980,27 @@ impl NovaFoldingCycle {
         let step_circuit = NovaStepCircuit::new(circuits.clone());
 
         if self.pp.is_none() {
-            let pp = PublicParams::<NovaEngine1, NovaEngine2, NovaStepCircuit>::setup(
-                &step_circuit,
-                &*NovaSNARK1::ck_floor(),
-                &*NovaSNARK2::ck_floor(),
-            )?;
-            let mut recursive_snark =
+            let pp = {
+                let _setup_span = span.child(vec![String::from("pp_setup")]);
+                PublicParams::<NovaEngine1, NovaEngine2, NovaStepCircuit>::setup(
+                    &step_circuit,
+                    &*NovaSNARK1::ck_floor(),
+                    &*NovaSNARK2::ck_floor(),
+                )?
+            };
+            let mut recursive_snark = {
+                let _new_span = span.child(vec![String::from("recursive_new")]);
                 RecursiveSNARK::<NovaEngine1, NovaEngine2, NovaStepCircuit>::new(
                     &pp,
                     &step_circuit,
                     &self.initial_z,
-                )?;
-            // 将内部计数推进到第一步
-            recursive_snark.prove_step(&pp, &step_circuit)?;
+                )?
+            };
+            {
+                let _prove_span = span.child(vec![String::from("prove_step")]);
+                // 将内部计数推进到第一步
+                recursive_snark.prove_step(&pp, &step_circuit)?;
+            }
             log_msg(
                 "DEBUG",
                 "NOVA",
@@ -1005,7 +1015,10 @@ impl NovaFoldingCycle {
                 .recursive_snark
                 .as_mut()
                 .ok_or(NovaFoldingError::NotInitialized)?;
-            recursive_snark.prove_step(pp, &step_circuit)?;
+            {
+                let _prove_span = span.child(vec![String::from("prove_step")]);
+                recursive_snark.prove_step(pp, &step_circuit)?;
+            }
             log_msg(
                 "DEBUG",
                 "NOVA",
@@ -1045,6 +1058,7 @@ impl NovaFoldingCycle {
 
     /// 完成折叠周期并生成最终证明。
     pub fn finalize(&mut self) -> Result<Option<NovaFinalProof>, NovaFoldingError> {
+        let span = perf::span(["Nova", "finalize"]);
         log_msg(
             "DEBUG",
             "NOVA",
@@ -1070,25 +1084,37 @@ impl NovaFoldingCycle {
             .ok_or(NovaFoldingError::NotInitialized)?;
 
         log_msg("DEBUG", "NOVA", None, "验证递归 SNARK 并生成压缩证明。");
-        recursive_snark.verify(pp, self.steps, &self.initial_z)?;
+        {
+            let _verify_span = span.child(vec![String::from("recursive_verify")]);
+            recursive_snark.verify(pp, self.steps, &self.initial_z)?;
+        }
 
-        let (pk, vk) = CompressedSNARK::<
-            NovaEngine1,
-            NovaEngine2,
-            NovaStepCircuit,
-            NovaSNARK1,
-            NovaSNARK2,
-        >::setup(pp)?;
+        let (pk, vk) = {
+            let _setup_span = span.child(vec![String::from("compressed_setup")]);
+            CompressedSNARK::<
+                NovaEngine1,
+                NovaEngine2,
+                NovaStepCircuit,
+                NovaSNARK1,
+                NovaSNARK2,
+            >::setup(pp)?
+        };
 
-        let compressed = CompressedSNARK::<
-            NovaEngine1,
-            NovaEngine2,
-            NovaStepCircuit,
-            NovaSNARK1,
-            NovaSNARK2,
-        >::prove(pp, &pk, recursive_snark)?;
+        let compressed = {
+            let _prove_span = span.child(vec![String::from("compressed_prove")]);
+            CompressedSNARK::<
+                NovaEngine1,
+                NovaEngine2,
+                NovaStepCircuit,
+                NovaSNARK1,
+                NovaSNARK2,
+            >::prove(pp, &pk, recursive_snark)?
+        };
 
-        compressed.verify(&vk, self.steps, &self.initial_z)?;
+        {
+            let _verify_span = span.child(vec![String::from("compressed_verify")]);
+            compressed.verify(&vk, self.steps, &self.initial_z)?;
+        }
 
         let proof_bytes = bincode::serialize(&compressed)
             .map_err(|err| NovaFoldingError::Serialization(err.to_string()))?;
@@ -1120,16 +1146,25 @@ impl NovaFoldingCycle {
         compressed_snark: &[u8],
         verifier_key: &[u8],
     ) -> Result<String, NovaFoldingError> {
+        let span = perf::span(["Nova", "verify_final_accumulator"]);
         type NovaCompressed =
             CompressedSNARK<NovaEngine1, NovaEngine2, NovaStepCircuit, NovaSNARK1, NovaSNARK2>;
-        let snark: NovaCompressed = bincode::deserialize(compressed_snark)
-            .map_err(|err| NovaFoldingError::Serialization(err.to_string()))?;
-        let vk: VerifierKey<NovaEngine1, NovaEngine2, NovaStepCircuit, NovaSNARK1, NovaSNARK2> =
+        let snark: NovaCompressed = {
+            let _deserialize_span = span.child(vec![String::from("deserialize_snark")]);
+            bincode::deserialize(compressed_snark)
+                .map_err(|err| NovaFoldingError::Serialization(err.to_string()))?
+        };
+        let vk: VerifierKey<NovaEngine1, NovaEngine2, NovaStepCircuit, NovaSNARK1, NovaSNARK2> = {
+            let _deserialize_span = span.child(vec![String::from("deserialize_vk")]);
             bincode::deserialize(verifier_key)
-                .map_err(|err| NovaFoldingError::Serialization(err.to_string()))?;
-        let outputs = snark
-            .verify(&vk, expected_steps, &[NovaScalar::ZERO, NovaScalar::ZERO])
-            .map_err(NovaFoldingError::NovaInternal)?;
+                .map_err(|err| NovaFoldingError::Serialization(err.to_string()))?
+        };
+        let outputs = {
+            let _verify_span = span.child(vec![String::from("verify")]);
+            snark
+                .verify(&vk, expected_steps, &[NovaScalar::ZERO, NovaScalar::ZERO])
+                .map_err(NovaFoldingError::NovaInternal)?
+        };
         if outputs.len() < 2 {
             return Err(NovaFoldingError::Validation(format!(
                 "expected 2 outputs, received {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod consensus;
 pub mod crypto;
 pub mod merkle;
+pub mod monitoring;
 pub mod p2p;
 pub mod roles;
 pub mod simulation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // 引入 bpst 项目中的配置模块
 use bpst::config::{DeploymentConfig, P2PSimConfig};
 // 初始化日志系统
+use bpst::monitoring::perf::PerfExportGuard;
 use bpst::utils::init_logging;
 // 引入 bpst 项目中的 simulation 模块，包含运行节点、用户进程和P2P模拟的功能
 use bpst::simulation::{
@@ -10,6 +11,7 @@ use log::error;
 
 // Rust 程序的主入口函数
 fn main() {
+    let _perf_export_guard = PerfExportGuard::from_env();
     // 初始化日志系统，确保控制台输出同时写入日志文件
     init_logging();
     // 获取命令行参数的迭代器

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -1,0 +1,1 @@
+pub mod perf;

--- a/src/monitoring/perf.rs
+++ b/src/monitoring/perf.rs
@@ -1,0 +1,391 @@
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use chrono::{DateTime, Utc};
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+
+#[derive(Clone, Default)]
+struct PerfContext {
+    node_id: Option<String>,
+    user_id: Option<String>,
+}
+
+thread_local! {
+    static CONTEXT_STACK: RefCell<Vec<PerfContext>> = RefCell::new(vec![PerfContext::default()]);
+}
+
+fn current_context() -> PerfContext {
+    CONTEXT_STACK.with(|stack| stack.borrow().last().cloned().unwrap_or_default())
+}
+
+fn push_context(ctx: PerfContext) {
+    CONTEXT_STACK.with(|stack| stack.borrow_mut().push(ctx));
+}
+
+fn pop_context() {
+    CONTEXT_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+        if stack.len() > 1 {
+            stack.pop();
+        }
+    });
+}
+
+fn read_cpu_cycles() -> Option<u64> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // Safety: _rdtsc has no safety requirements beyond running on x86/x86_64.
+        Some(unsafe { core::arch::x86_64::_rdtsc() })
+    }
+    #[cfg(target_arch = "x86")]
+    {
+        Some(unsafe { core::arch::x86::_rdtsc() })
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        None
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PerfRecord {
+    pub start_time: DateTime<Utc>,
+    pub node_id: Option<String>,
+    pub user_id: Option<String>,
+    pub stack: Vec<String>,
+    pub duration_ns: u128,
+    pub cpu_cycles: Option<u64>,
+}
+
+#[derive(Default)]
+pub struct PerformanceMonitor {
+    records: Mutex<Vec<PerfRecord>>,
+}
+
+static PERFORMANCE_MONITOR: Lazy<PerformanceMonitor> = Lazy::new(PerformanceMonitor::default);
+
+pub fn monitor() -> &'static PerformanceMonitor {
+    &PERFORMANCE_MONITOR
+}
+
+impl PerformanceMonitor {
+    pub fn start_span<I, L>(&'static self, labels: I) -> PerfSpan
+    where
+        I: IntoIterator<Item = L>,
+        L: Into<String>,
+    {
+        self.start_span_with_context(None::<String>, None::<String>, labels)
+    }
+
+    pub fn start_span_with_context<I, L, N, U>(
+        &'static self,
+        node_id: Option<N>,
+        user_id: Option<U>,
+        labels: I,
+    ) -> PerfSpan
+    where
+        I: IntoIterator<Item = L>,
+        L: Into<String>,
+        N: Into<String>,
+        U: Into<String>,
+    {
+        let context = current_context();
+        let node_id = node_id
+            .map(|n| n.into())
+            .or_else(|| context.node_id.clone());
+        let user_id = user_id
+            .map(|u| u.into())
+            .or_else(|| context.user_id.clone());
+        PerfSpan::new(
+            self,
+            node_id,
+            user_id,
+            labels.into_iter().map(|label| label.into()).collect(),
+        )
+    }
+
+    pub fn record(&self, record: PerfRecord) {
+        self.records.lock().push(record);
+    }
+
+    pub fn export_csv(&self) -> String {
+        let mut csv = String::from(
+            "start_time,node_id,user_id,stack,duration_ns,cpu_cycles,instructions_est\n",
+        );
+        for record in self.records.lock().iter() {
+            let stack = record.stack.join(";");
+            let node = record.node_id.clone().unwrap_or_else(|| "-".to_string());
+            let user = record.user_id.clone().unwrap_or_else(|| "-".to_string());
+            let cycles = record
+                .cpu_cycles
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let row = format!(
+                "{timestamp}.{subsec:09},{node},{user},\"{stack}\",{duration},{cycles},{instructions}\n",
+                timestamp = record.start_time.format("%Y-%m-%dT%H:%M:%S"),
+                subsec = record.start_time.timestamp_subsec_nanos(),
+                node = node,
+                user = user,
+                stack = stack,
+                duration = record.duration_ns,
+                cycles = cycles,
+                instructions = cycles,
+            );
+            csv.push_str(&row);
+        }
+        csv
+    }
+
+    pub fn export_flamegraph(&self) -> String {
+        let mut out = String::new();
+        for record in self.records.lock().iter() {
+            let mut stack = Vec::new();
+            if let Some(node) = &record.node_id {
+                stack.push(format!("node:{}", node));
+            }
+            if let Some(user) = &record.user_id {
+                stack.push(format!("user:{}", user));
+            }
+            stack.extend(record.stack.iter().cloned());
+            if stack.is_empty() {
+                stack.push("unknown".to_string());
+            }
+            let duration = record.duration_ns.max(1);
+            out.push_str(&format!("{} {}\n", stack.join(";"), duration));
+        }
+        out
+    }
+
+    pub fn write_csv_to<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
+        std::fs::write(path, self.export_csv())
+    }
+
+    pub fn write_flamegraph_to<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
+        std::fs::write(path, self.export_flamegraph())
+    }
+
+    pub fn clear(&self) {
+        self.records.lock().clear();
+    }
+
+    pub fn records(&self) -> Vec<PerfRecord> {
+        self.records.lock().clone()
+    }
+}
+
+#[must_use = "performance span must be kept alive to record metrics"]
+pub struct PerfSpan {
+    monitor: &'static PerformanceMonitor,
+    node_id: Option<String>,
+    user_id: Option<String>,
+    stack: Vec<String>,
+    start_time: DateTime<Utc>,
+    start_instant: Instant,
+    start_cycles: Option<u64>,
+    closed: bool,
+}
+
+impl PerfSpan {
+    fn new(
+        monitor: &'static PerformanceMonitor,
+        node_id: Option<String>,
+        user_id: Option<String>,
+        stack: Vec<String>,
+    ) -> Self {
+        let start_time = Utc::now();
+        let start_instant = Instant::now();
+        let start_cycles = read_cpu_cycles();
+        Self {
+            monitor,
+            node_id,
+            user_id,
+            stack,
+            start_time,
+            start_instant,
+            start_cycles,
+            closed: false,
+        }
+    }
+
+    pub fn child<I, L>(&self, labels: I) -> PerfSpan
+    where
+        I: IntoIterator<Item = L>,
+        L: Into<String>,
+    {
+        let mut stack = self.stack.clone();
+        stack.extend(labels.into_iter().map(|label| label.into()));
+        PerfSpan::new(
+            self.monitor,
+            self.node_id.clone(),
+            self.user_id.clone(),
+            stack,
+        )
+    }
+
+    pub fn finish(mut self) {
+        self.close();
+    }
+
+    fn close(&mut self) {
+        if self.closed {
+            return;
+        }
+        let duration = self.start_instant.elapsed().as_nanos();
+        let end_cycles = read_cpu_cycles();
+        let cpu_cycles = match (self.start_cycles, end_cycles) {
+            (Some(start), Some(end)) => Some(end.saturating_sub(start)),
+            _ => None,
+        };
+        self.monitor.record(PerfRecord {
+            start_time: self.start_time,
+            node_id: self.node_id.clone(),
+            user_id: self.user_id.clone(),
+            stack: self.stack.clone(),
+            duration_ns: duration,
+            cpu_cycles,
+        });
+        self.closed = true;
+    }
+}
+
+impl Drop for PerfSpan {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+pub struct PerfContextGuard {
+    active: bool,
+}
+
+impl PerfContextGuard {
+    pub fn new<N, U>(node_id: Option<N>, user_id: Option<U>) -> Self
+    where
+        N: Into<String>,
+        U: Into<String>,
+    {
+        let ctx = PerfContext {
+            node_id: node_id.map(|n| n.into()),
+            user_id: user_id.map(|u| u.into()),
+        };
+        push_context(ctx);
+        Self { active: true }
+    }
+}
+
+impl Drop for PerfContextGuard {
+    fn drop(&mut self) {
+        if self.active {
+            pop_context();
+            self.active = false;
+        }
+    }
+}
+
+pub struct PerfExportGuard {
+    csv_path: Option<PathBuf>,
+    flame_path: Option<PathBuf>,
+    clear_after: bool,
+}
+
+impl PerfExportGuard {
+    pub fn from_env() -> Self {
+        let csv_path = std::env::var("BPST_PERF_CSV").ok().map(PathBuf::from);
+        let flame_path = std::env::var("BPST_PERF_FLAME").ok().map(PathBuf::from);
+        let clear_after = std::env::var("BPST_PERF_CLEAR")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(true);
+        Self {
+            csv_path,
+            flame_path,
+            clear_after,
+        }
+    }
+
+    pub fn new(csv_path: Option<PathBuf>, flame_path: Option<PathBuf>, clear_after: bool) -> Self {
+        Self {
+            csv_path,
+            flame_path,
+            clear_after,
+        }
+    }
+}
+
+impl Drop for PerfExportGuard {
+    fn drop(&mut self) {
+        if let Some(path) = &self.csv_path {
+            if let Err(err) = monitor().write_csv_to(path) {
+                eprintln!(
+                    "failed to write performance CSV {}: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
+        if let Some(path) = &self.flame_path {
+            if let Err(err) = monitor().write_flamegraph_to(path) {
+                eprintln!(
+                    "failed to write performance flamegraph {}: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
+        if self.clear_after {
+            monitor().clear();
+        }
+    }
+}
+
+pub fn enter_context<N, U>(node_id: Option<N>, user_id: Option<U>) -> PerfContextGuard
+where
+    N: Into<String>,
+    U: Into<String>,
+{
+    PerfContextGuard::new(node_id, user_id)
+}
+
+pub fn span<I, L>(labels: I) -> PerfSpan
+where
+    I: IntoIterator<Item = L>,
+    L: Into<String>,
+{
+    monitor().start_span(labels)
+}
+
+pub fn span_with_context<I, L, N, U>(node_id: Option<N>, user_id: Option<U>, labels: I) -> PerfSpan
+where
+    I: IntoIterator<Item = L>,
+    L: Into<String>,
+    N: Into<String>,
+    U: Into<String>,
+{
+    monitor().start_span_with_context(node_id, user_id, labels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_span_duration_and_stack() {
+        monitor().clear();
+        {
+            let _ctx = enter_context(Some("node-test".to_string()), None::<String>);
+            let span = span(["module", "operation"]);
+            {
+                let _child = span.child(vec![String::from("sub")]);
+            }
+            span.finish();
+        }
+        let records = monitor().records();
+        assert!(records
+            .iter()
+            .any(|rec| rec.stack.contains(&"module".to_string())));
+        assert!(records
+            .iter()
+            .any(|rec| rec.node_id.as_deref() == Some("node-test")));
+    }
+}

--- a/src/p2p/node.rs
+++ b/src/p2p/node.rs
@@ -29,6 +29,7 @@ use crate::common::datastructures::{
 use crate::consensus::blockchain::Blockchain; // 区块链逻辑
 use crate::crypto::deserialize_g2; // G2点反序列化工具
 use crate::crypto::dpdp::DPDP; // dPDP 密码学逻辑
+use crate::monitoring::perf;
 use crate::roles::miner::Miner; // 矿工角色
 use crate::roles::prover::Prover; // 证明者角色
 use crate::storage::manager::{FileDataError, StorageManager}; // 存储管理器
@@ -557,6 +558,8 @@ impl Node {
 
     /// 处理dPDP挑战请求，生成并返回证明
     fn handle_dpdp_challenge(&mut self, data: &Value) -> CommandResponse {
+        let _ctx = perf::enter_context(Some(self.node_id.clone()), None::<String>);
+        let _span = perf::span(["dPDP", "handle_challenge"]);
         let file_id = data.get("file_id").and_then(Value::as_str).unwrap_or("");
         let indices: Vec<usize> = data
             .get("indices")
@@ -1343,6 +1346,8 @@ impl Node {
 
     /// 创建新区块（仅由领导者调用）
     fn create_block(&mut self, height: usize, winning_proofs: Vec<BobtailProof>) {
+        let _ctx = perf::enter_context(Some(self.node_id.clone()), None::<String>);
+        let _span = perf::span(["CONSENSUS", "create_block"]);
         log_msg(
             "SUCCESS",
             "CONSENSUS",

--- a/src/p2p/user_node.rs
+++ b/src/p2p/user_node.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 use crate::common::datastructures::FileChunk;
 use crate::config::P2PSimConfig;
 use crate::crypto::{folding::NovaFoldingCycle, serialize_g2};
+use crate::monitoring::perf;
 use crate::roles::file_owner::FileOwner;
 use crate::utils::{log_msg, with_cpu_heavy_limit};
 
@@ -487,6 +488,8 @@ impl UserNode {
         stored_files: &Arc<Mutex<HashMap<String, StoredFileRecord>>>,
         args: FinalProofArgs<'_>,
     ) -> Result<(), String> {
+        let _ctx = perf::enter_context(None::<String>, Some(args.owner_id.to_string()));
+        let _span = perf::span(["Nova", "user_verify_final"]);
         let (record_opt, already_verified) = {
             let map = stored_files.lock();
             match map.get(args.file_id) {

--- a/src/roles/file_owner.rs
+++ b/src/roles/file_owner.rs
@@ -4,6 +4,7 @@ use rand::{Rng, RngCore};
 // 导入项目内的数据结构和密码学模块
 use crate::common::datastructures::{DPDPParams, DPDPTags, FileChunk};
 use crate::crypto::dpdp::DPDP;
+use crate::monitoring::perf;
 use crate::utils::log_msg;
 
 /// FileOwner 结构体定义了文件所有者的角色
@@ -69,6 +70,8 @@ impl FileOwner {
     /// dPDP 设置阶段：为文件生成标签并打包成块
     /// 这是将原始文件转化为可被 dPDP 方案保护的格式的关键步骤
     pub fn dpdp_setup(&mut self, file_bytes: &[u8]) -> Vec<FileChunk> {
+        let _ctx = perf::enter_context(None::<String>, Some(self.owner_id.clone()));
+        let _span = perf::span(["dPDP", "owner_setup"]);
         // 1. 将文件字节流分割成原始数据块
         let raw_chunks = self.split_file(file_bytes);
         // 2. 使用 dPDP 私钥为所有数据块生成对应的标签
@@ -102,6 +105,8 @@ impl FileOwner {
         max_size_bytes: usize, // 随机生成文件的最大尺寸
         num_nodes: usize,      // 期望存储该文件的节点数量（当前实现中未直接使用，但可用于分发策略）
     ) -> (Vec<FileChunk>, usize) {
+        let _ctx = perf::enter_context(None::<String>, Some(self.owner_id.clone()));
+        let _span = perf::span(["dPDP", "prepare_request"]);
         // 在发起新的存储请求前生成一个全新的文件 ID，避免重复使用导致冲突
         self.file_id = Self::generate_file_id(&self.owner_id);
         // 1. 在指定范围内随机确定文件大小

--- a/src/roles/prover.rs
+++ b/src/roles/prover.rs
@@ -7,6 +7,7 @@ use num_bigint::BigUint;
 // 导入项目内的数据结构和密码学模块
 use crate::common::datastructures::{DPDPProof, DPDPTags};
 use crate::crypto::dpdp::DPDP;
+use crate::monitoring::perf;
 use crate::utils::log_msg;
 
 /// dPDP 挑战向量类型别名，元素为 (块索引, 挑战系数)。
@@ -53,6 +54,8 @@ impl Prover {
         timestamp: u64,
         challenge_size: Option<usize>,
     ) -> (DPDPProof, ChallengeVector, ContributionVector) {
+        let _ctx = perf::enter_context(Some(self.node_id.clone()), None::<String>);
+        let _span = perf::span(["dPDP", "prove"]);
         // 1. 根据上下文（前一个块哈希、时间戳）和文件标签生成一个确定性的随机挑战
         let challenge = DPDP::gen_chal(prev_hash, timestamp, file_tags, challenge_size);
 

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -13,6 +13,7 @@ use crate::crypto::folding::{
     state_update_relaxed_r1cs, NovaFinalProof, NovaFoldingCycle, NovaFoldingError, NovaRoundResult,
     RelaxedR1CS,
 };
+use crate::monitoring::perf;
 use crate::storage::state::ServerStorage;
 use crate::utils::{h_join, sha256_hex};
 use serde_json::Value as JsonValue;
@@ -528,6 +529,8 @@ impl StorageManager {
     }
 
     pub fn rollback_to_height(&self, target_height: u64) {
+        let _ctx = perf::enter_context(Some(self.node_id.clone()), None::<String>);
+        let _span = perf::span(["Nova", "rollback_to_height"]);
         let mut inner = self.inner.lock();
         let mut affected = false;
         let file_ids: Vec<String> = inner.file_cycles.keys().cloned().collect();
@@ -587,6 +590,8 @@ impl StorageManager {
         contributions: &[(usize, BigUint, Vec<u8>)],
         round_salt: &str,
     ) -> Option<NovaRoundResult> {
+        let _ctx = perf::enter_context(Some(self.node_id.clone()), None::<String>);
+        let _span = perf::span(["Nova", "process_round"]);
         let mut inner = self.inner.lock();
         let block_height = block.height;
         if inner


### PR DESCRIPTION
## Summary
- add a shared performance monitoring facility with CSV/flamegraph exports and shutdown guard
- instrument dPDP and Nova folding workflows with hierarchical spans and CPU cycle accounting
- propagate node/user context through owner, prover, storage, and P2P paths to attribute metrics

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f88f8033608327b381c48b324fb391