### PR TITLE
Enable SVG flamegraph export and profile folding functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -138,7 +139,7 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-integer",
@@ -201,7 +202,7 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -327,6 +328,7 @@ dependencies = [
  "ff",
  "hex",
  "indexmap",
+ "inferno",
  "light-poseidon",
  "log",
  "nova-snark",
@@ -349,6 +351,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder"
@@ -396,6 +404,46 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.0",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
@@ -471,6 +519,20 @@ dependencies = [
  "dispatch",
  "nix",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -636,6 +698,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,12 +771,30 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -744,9 +836,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "env_logger",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
 ]
 
 [[package]]
@@ -758,6 +873,17 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -923,7 +1049,7 @@ dependencies = [
  "digest",
  "ff",
  "generic-array 1.2.0",
- "getrandom",
+ "getrandom 0.2.16",
  "halo2curves",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -960,6 +1086,16 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -1079,6 +1215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1231,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -1120,7 +1271,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1180,6 +1331,15 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1323,6 +1483,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1636,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1744,6 +1925,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0"
 hex = "0.4"
 parking_lot = "0.12"
 crossbeam-channel = "0.5"
+inferno = "0.11"
 ark-ff = "0.5"
 ark-ec = "0.5"
 ark-std = { version = "0.5", default-features = false, features = ["std"] }

--- a/src/crypto/dpdp.rs
+++ b/src/crypto/dpdp.rs
@@ -22,6 +22,7 @@ pub type ChallengedChunkData = HashMap<usize, (Vec<u8>, MerkleProofPath)>;
 
 /// 将任意消息哈希到 BN254 G1 群，作为 dPDP 中的基点。
 pub fn hash_to_g1(message: &[u8]) -> G1Projective {
+    let _span = perf::span(["dPDP", "hash_to_g1"]);
     let field_elem = hash_to_field(message);
     let mut bytes = field_elem.to_bytes_be();
     if bytes.len() > 32 {

--- a/src/crypto/folding.rs
+++ b/src/crypto/folding.rs
@@ -41,6 +41,7 @@ pub struct RelaxedR1CSConstraint<F: PrimeField> {
 impl<F: PrimeField> RelaxedR1CSConstraint<F> {
     /// 创建一个新的松弛 R1CS 约束。
     pub fn new(a: Vec<(usize, F)>, b: Vec<(usize, F)>, c: Vec<(usize, F)>, error: F) -> Self {
+        let _span = perf::span(["Folding", "RelaxedR1CSConstraint::new"]);
         Self { a, b, c, error }
     }
 }
@@ -67,6 +68,7 @@ pub struct RelaxedR1CS<F: PrimeField> {
 impl<F: PrimeField> RelaxedR1CS<F> {
     /// 检查存储的赋值是否满足所有约束。
     pub fn is_satisfied(&self) -> bool {
+        let _span = perf::span(["Folding", "RelaxedR1CS::is_satisfied"]);
         let eval = |lc: &[(usize, F)], assignments: &[F]| -> F {
             lc.iter().fold(F::zero(), |acc, (idx, coeff)| {
                 let val = assignments.get(*idx).copied().unwrap_or_else(F::zero);
@@ -75,6 +77,13 @@ impl<F: PrimeField> RelaxedR1CS<F> {
         };
 
         self.constraints.iter().all(|constraint| {
+            let _constraint_span = _span.child(vec![
+                String::from("constraint"),
+                format!(
+                    "len_{}",
+                    constraint.a.len() + constraint.b.len() + constraint.c.len()
+                ),
+            ]);
             let a = eval(&constraint.a, &self.assignments);
             let b = eval(&constraint.b, &self.assignments);
             let c = eval(&constraint.c, &self.assignments);
@@ -84,9 +93,11 @@ impl<F: PrimeField> RelaxedR1CS<F> {
 
     /// 返回序列化后的见证，用于后续的折叠操作。
     pub fn witness_serialized(&self) -> Vec<Vec<u8>> {
+        let _span = perf::span(["Folding", "RelaxedR1CS::witness_serialized"]);
         self.witness
             .iter()
             .map(|value| {
+                let _witness_span = _span.child(vec![String::from("witness")]);
                 let bigint = (*value).into_bigint();
                 let bytes = bigint.to_bytes_be();
                 let mut out = vec![0u8; 32];
@@ -116,6 +127,7 @@ pub struct RelaxedR1CSBuilder<F: PrimeField> {
 impl<F: PrimeField> RelaxedR1CSBuilder<F> {
     /// 创建一个新的构建器。
     pub fn new() -> Self {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::new"]);
         Self {
             // 预分配一个值为 1 的常量
             assignments: vec![F::one()],
@@ -128,6 +140,7 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
 
     /// 设置松弛标量 u。
     pub fn set_relaxation_parameter(&mut self, u: F) {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::set_relaxation_parameter"]);
         self.u = u;
     }
 
@@ -141,6 +154,7 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
 
     /// 分配一个公共输入变量。
     pub fn alloc_input(&mut self, value: F) -> usize {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::alloc_input"]);
         let idx = self.alloc_variable(value);
         self.is_input[idx] = true;
         self.input_indexes.push(idx);
@@ -149,11 +163,13 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
 
     /// 分配一个私有见证变量。
     pub fn alloc_witness(&mut self, value: F) -> usize {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::alloc_witness"]);
         self.alloc_variable(value)
     }
 
     /// 分配一个常量值。
     pub fn alloc_constant(&mut self, value: F) -> usize {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::alloc_constant"]);
         let idx = self.alloc_witness(value);
         let mut a = vec![(idx, F::one())];
         if !value.is_zero() {
@@ -170,6 +186,7 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
 
     /// 强制两个变量相等。
     pub fn enforce_equal(&mut self, left: usize, right: usize) {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::enforce_equal"]);
         self.constraints.push(RelaxedR1CSConstraint::new(
             vec![(left, F::one()), (right, -F::one())], // left - right
             vec![(0, F::one())],                        // * 1
@@ -180,6 +197,7 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
 
     /// 强制一个变量为布尔值 (0 或 1)。
     pub fn enforce_boolean(&mut self, var: usize) {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::enforce_boolean"]);
         let minus_one = self.assignments[var] - F::one();
         let minus_one_idx = self.alloc_witness(minus_one);
         // 添加约束: var * (var - 1) = 0
@@ -202,6 +220,7 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
 
     /// 两个变量相乘。
     pub fn mul(&mut self, left: usize, right: usize) -> usize {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::mul"]);
         let value = self.assignments[left] * self.assignments[right];
         let out = self.alloc_witness(value);
         self.constraints.push(RelaxedR1CSConstraint::new(
@@ -215,6 +234,7 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
 
     /// 计算变量的线性组合。
     pub fn linear_combination(&mut self, terms: &[(usize, F)], constant: F) -> usize {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::linear_combination"]);
         let mut value = constant;
         for (idx, coeff) in terms {
             value += self.assignments[*idx] * coeff;
@@ -238,6 +258,7 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
 
     /// 完成构建并返回松弛 R1CS 实例。
     pub fn finish(mut self) -> RelaxedR1CS<F> {
+        let _span = perf::span(["Folding", "RelaxedR1CSBuilder::finish"]);
         let u = self.u;
         self.assignments.push(u);
         self.is_input.push(false);
@@ -373,14 +394,19 @@ pub fn dpdp_verification_relaxed_r1cs(
     proof: &DPDPProof,
     challenge: &[(usize, BigUint)],
 ) -> (RelaxedR1CS<Fr>, bool) {
+    let span = perf::span(["Folding", "dpdp_verification_relaxed_r1cs"]);
     // 验证 dPDP 证明
     let sigma = deserialize_g1(&proof.sigma);
     let sigma_affine = G1Affine::from(sigma);
     let g_affine = G2Affine::from(params.g);
-    let lhs = Bn254::pairing(sigma_affine, g_affine);
+    let lhs = {
+        let _pairing_span = span.child(vec![String::from("pairing_lhs")]);
+        Bn254::pairing(sigma_affine, g_affine)
+    };
 
     let mut agg_h = G1Projective::zero();
     for (index, value) in challenge {
+        let _challenge_span = span.child(vec![String::from("challenge"), format!("idx_{}", index)]);
         let h_i = hash_to_g1(index.to_string().as_bytes());
         let scalar = biguint_to_fr(value);
         agg_h += h_i.mul_bigint(scalar.into_bigint());
@@ -390,10 +416,14 @@ pub fn dpdp_verification_relaxed_r1cs(
     let mu_fr = biguint_to_fr(&mu_big);
     let mu_u = params.u.mul_bigint(mu_fr.into_bigint());
     let rhs_point = agg_h + mu_u;
-    let rhs = Bn254::pairing(G1Affine::from(rhs_point), G2Affine::from(params.pk_beta));
+    let rhs = {
+        let _pairing_span = span.child(vec![String::from("pairing_rhs")]);
+        Bn254::pairing(G1Affine::from(rhs_point), G2Affine::from(params.pk_beta))
+    };
     let valid = lhs == rhs;
 
     // 构建 R1CS 电路
+    let _builder_span = span.child(vec![String::from("builder")]);
     let mut builder = RelaxedR1CSBuilder::<Fr>::new();
     let mu_input = builder.alloc_input(mu_fr);
     let mu_witness = builder.alloc_witness(mu_fr);
@@ -442,25 +472,30 @@ pub fn block_validation_relaxed_r1cs(
     expected_prev_hash: &str,
     expected_height: u64,
 ) -> RelaxedR1CS<Fr> {
+    let span = perf::span(["Folding", "block_validation_relaxed_r1cs"]);
     let mut builder = RelaxedR1CSBuilder::<Fr>::new();
 
     // 约束 prev_hash
+    let _prev_span = span.child(vec![String::from("prev_hash")]);
     let prev_hash_var = builder.alloc_input(fr_from_hex(&block.prev_hash));
     let expected_prev_hash_var = builder.alloc_input(fr_from_hex(expected_prev_hash));
     builder.enforce_equal(prev_hash_var, expected_prev_hash_var);
 
     // 约束 height
+    let _height_span = span.child(vec![String::from("height")]);
     let height_var = builder.alloc_input(Fr::from(block.height));
     let expected_height_var = builder.alloc_input(Fr::from(expected_height));
     builder.enforce_equal(height_var, expected_height_var);
 
     // 约束 proofs count
+    let _proof_span = span.child(vec![String::from("proofs_count")]);
     let proofs_count = Fr::from(block.body.selected_k_proofs.len() as u64);
     let proofs_var = builder.alloc_input(proofs_count);
     let bobtail_k_var = builder.alloc_input(Fr::from(block.bobtail_k));
     builder.enforce_equal(proofs_var, bobtail_k_var);
 
     // 约束 header_hash
+    let _header_span = span.child(vec![String::from("header_hash")]);
     let header_hash = block.header_hash();
     let header_var = builder.alloc_input(fr_from_hex(&header_hash));
     let recomputed_header = builder.alloc_witness(fr_from_hex(&header_hash));
@@ -474,9 +509,11 @@ pub fn state_update_relaxed_r1cs(
     state: &StorageStateTree,
     updates: &[(String, String)],
 ) -> RelaxedR1CS<Fr> {
+    let span = perf::span(["Folding", "state_update_relaxed_r1cs"]);
     let mut builder = RelaxedR1CSBuilder::<Fr>::new();
 
     // 计算更新前的状态树根
+    let _before_span = span.child(vec![String::from("before_root")]);
     let mut before = state.clone();
     before.build();
     let before_root = before.root();
@@ -485,6 +522,7 @@ pub fn state_update_relaxed_r1cs(
     builder.enforce_equal(before_var, before_copy);
 
     // 计算更新后的状态树根
+    let _after_span = span.child(vec![String::from("after_root")]);
     let mut after = before.clone();
     for (file_id, new_root) in updates {
         after.file_roots.insert(file_id.clone(), new_root.clone());
@@ -497,6 +535,7 @@ pub fn state_update_relaxed_r1cs(
 
     // 如果根哈希相同，则 same_flag 为 1，否则为 0。
     // 约束 (after_root - before_root)^2 * same_flag = 0
+    let _diff_span = span.child(vec![String::from("diff_flag")]);
     let diff = builder.linear_combination(
         &[(after_var, Fr::one()), (before_var, -Fr::one())],
         Fr::zero(),
@@ -515,6 +554,7 @@ pub fn state_update_relaxed_r1cs(
 
     // 验证每个文件的根哈希是否已正确更新
     for (file_id, new_root) in updates {
+        let _file_span = span.child(vec![String::from("file"), file_id.clone()]);
         let final_value = after
             .file_roots
             .get(file_id)
@@ -539,6 +579,7 @@ pub struct IncrementalRelaxedCircuit<F: PrimeField> {
 
 impl<F: PrimeField> IncrementalRelaxedCircuit<F> {
     pub fn new() -> Self {
+        let _span = perf::span(["Folding", "IncrementalRelaxedCircuit::new"]);
         Self {
             steps: Vec::new(),
             accumulator: F::zero(),
@@ -547,6 +588,7 @@ impl<F: PrimeField> IncrementalRelaxedCircuit<F> {
 
     /// 吸收一个新的电路实例。
     pub fn absorb(&mut self, circuit: RelaxedR1CS<F>) {
+        let _span = perf::span(["Folding", "IncrementalRelaxedCircuit::absorb"]);
         let delta = F::from((self.steps.len() + 1) as u64);
         self.accumulator += delta;
         self.steps.push(circuit);
@@ -554,12 +596,14 @@ impl<F: PrimeField> IncrementalRelaxedCircuit<F> {
 
     /// 合并另一个累积电路。
     pub fn merge(&mut self, other: &Self) {
+        let _span = perf::span(["Folding", "IncrementalRelaxedCircuit::merge"]);
         self.accumulator += other.accumulator;
         self.steps.extend(other.steps.clone());
     }
 
     /// 返回总约束数。
     pub fn total_constraints(&self) -> usize {
+        let _span = perf::span(["Folding", "IncrementalRelaxedCircuit::total_constraints"]);
         self.steps
             .iter()
             .map(|circuit| circuit.num_constraints)
@@ -905,6 +949,7 @@ pub struct NovaFoldingCycle {
 
 impl NovaFoldingCycle {
     pub fn new(storage_period: usize) -> Self {
+        let _span = perf::span(["Folding", "NovaFoldingCycle::new"]);
         // log_msg(
         //     "DEBUG",
         //     "NOVA",
@@ -924,10 +969,12 @@ impl NovaFoldingCycle {
     }
 
     pub fn storage_period(&self) -> usize {
+        let _span = perf::span(["Folding", "NovaFoldingCycle::storage_period"]);
         self.storage_period
     }
 
     pub fn steps_completed(&self) -> usize {
+        let _span = perf::span(["Folding", "NovaFoldingCycle::steps_completed"]);
         self.steps
     }
 

--- a/src/monitoring/perf.rs
+++ b/src/monitoring/perf.rs
@@ -1,10 +1,14 @@
 use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io::{Cursor, Error, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
+
+use inferno::flamegraph::{from_reader, Options};
 
 #[derive(Clone, Default)]
 struct PerfContext {
@@ -138,8 +142,8 @@ impl PerformanceMonitor {
         csv
     }
 
-    pub fn export_flamegraph(&self) -> String {
-        let mut out = String::new();
+    fn collapsed_stacks(&self) -> Vec<(String, u128)> {
+        let mut aggregated: HashMap<String, u128> = HashMap::new();
         for record in self.records.lock().iter() {
             let mut stack = Vec::new();
             if let Some(node) = &record.node_id {
@@ -153,9 +157,31 @@ impl PerformanceMonitor {
                 stack.push("unknown".to_string());
             }
             let duration = record.duration_ns.max(1);
-            out.push_str(&format!("{} {}\n", stack.join(";"), duration));
+            let entry = aggregated.entry(stack.join(";")).or_insert(0);
+            *entry = entry.saturating_add(duration);
+        }
+        let mut collapsed: Vec<_> = aggregated.into_iter().collect();
+        collapsed.sort_by(|a, b| a.0.cmp(&b.0));
+        collapsed
+    }
+
+    pub fn export_collapsed_flamegraph(&self) -> String {
+        let mut out = String::new();
+        for (stack, duration) in self.collapsed_stacks() {
+            out.push_str(&format!("{} {}\n", stack, duration));
         }
         out
+    }
+
+    pub fn export_flamegraph_svg(&self) -> std::io::Result<String> {
+        let mut options = Options::default();
+        options.count_name = "ns".to_string();
+        let collapsed = self.export_collapsed_flamegraph();
+        let mut reader = Cursor::new(collapsed);
+        let mut output = Vec::new();
+        from_reader(&mut options, &mut reader, &mut output)
+            .map_err(|err| Error::new(ErrorKind::Other, err.to_string()))?;
+        String::from_utf8(output).map_err(|err| Error::new(ErrorKind::InvalidData, err))
     }
 
     pub fn write_csv_to<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
@@ -163,7 +189,8 @@ impl PerformanceMonitor {
     }
 
     pub fn write_flamegraph_to<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
-        std::fs::write(path, self.export_flamegraph())
+        let svg = self.export_flamegraph_svg()?;
+        std::fs::write(path, svg)
     }
 
     pub fn clear(&self) {
@@ -387,5 +414,16 @@ mod tests {
         assert!(records
             .iter()
             .any(|rec| rec.node_id.as_deref() == Some("node-test")));
+    }
+
+    #[test]
+    fn exports_svg_flamegraph() {
+        monitor().clear();
+        {
+            let _ctx = enter_context(Some("node-a".to_string()), Some("user-a".to_string()));
+            let _span = span(["task", "unit"]);
+        }
+        let svg = monitor().export_flamegraph_svg().expect("svg output");
+        assert!(svg.contains("<svg"));
     }
 }


### PR DESCRIPTION
## Summary
- add the inferno flamegraph dependency and convert the performance exporter to emit SVG output
- aggregate span stacks before rendering, keep CSV export, and add a regression test for the SVG writer
- instrument folding and dPDP helpers with per-function spans so node/user contexts are captured during profiling

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f8aa4fb24083279dbf85057167a1e9