### PR TITLE
Refine consensus pressure metrics and add monitoring guide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +328,7 @@ dependencies = [
  "ark-std",
  "bincode",
  "chrono",
+ "criterion",
  "crossbeam-channel",
  "ctrlc",
  "env_logger",
@@ -344,6 +351,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "windows",
 ]
 
 [[package]]
@@ -369,6 +377,12 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -403,6 +417,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link 0.2.0",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -467,6 +508,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +574,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -727,6 +808,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "halo2curves"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,7 +909,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.0",
 ]
 
 [[package]]
@@ -891,6 +983,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1138,6 +1239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,6 +1685,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1756,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1706,6 +1842,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,7 +1879,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.2.0",
- "windows-result",
+ "windows-result 0.4.0",
  "windows-strings",
 ]
 
@@ -1751,6 +1916,15 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,18 @@ ff = "0.13"
 ctrlc = "3.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "time"] }
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.54", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }
+
 [features]
 default = []
+
+[dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+name = "dpdp_folding"
+harness = false

--- a/MONITORING_GUIDE.md
+++ b/MONITORING_GUIDE.md
@@ -1,0 +1,68 @@
+# 运行与性能监控指引
+
+本指南介绍如何启动 BPoSt 项目、运行基准测试，并导出性能监控结果。示例命令默认在项目根目录执行。
+
+## 运行节点模拟
+
+1. 构建项目：
+   ```bash
+   cargo build
+   ```
+2. 运行默认的 P2P 模拟：
+   ```bash
+   cargo run
+   ```
+3. 以子命令方式启动特定角色（示例）：
+   ```bash
+   cargo run -- node
+   cargo run -- user
+   cargo run -- deploy ./deployment/config.json
+   ```
+
+## 基准测试 dPDP 与 Folding
+
+1. 预先构建基准测试所需依赖：
+   ```bash
+   cargo bench --no-run
+   ```
+2. 执行全部 Criterion 基准：
+   ```bash
+   cargo bench
+   ```
+3. 若只需运行指定基准，可使用 Criterion 的过滤功能：
+   ```bash
+   cargo bench -- dpdp
+   cargo bench -- folding
+   ```
+
+基准完成后，Criterion 会在 `target/criterion` 目录生成详细报告，可通过浏览器打开相应的 `report/index.html`。
+
+## 查看性能监控数据
+
+性能监控通过 `bpst::monitoring::perf` 模块自动采集 Span 信息，并在 Windows 上使用 `QueryThreadCycleTime` 记录 CPU cycle。采集结果可通过以下方式导出：
+
+1. 设置导出环境变量并启动程序：
+   ```bash
+   BPST_PERF_CSV=perf.csv \
+   BPST_PERF_FLAME=perf.svg \
+   BPST_PERF_CLEAR=1 \
+   cargo run -- node
+   ```
+   - `BPST_PERF_CSV`：导出记录为 CSV。
+   - `BPST_PERF_FLAME`：导出压缩火焰图（SVG）。
+   - `BPST_PERF_CLEAR`：程序退出后是否清空内存数据（默认 `true`）。
+2. 使用 `PerfExportGuard` 会在程序结束时写出文件，并将 CSV 中的 `cpu_cycles` 与 `instructions_est` 列对齐。
+3. `consensus_pressure_report()` 会优先以 CPU cycle 计算各根 Span 的算力占比，当 cycle 不可用时回退到纳秒时长。
+
+## 清理监控数据
+
+在需要重新采集数据时，可调用：
+```rust
+bpst::monitoring::perf::monitor().clear();
+```
+或直接删除导出的 CSV/SVG 文件。
+
+## 注意事项
+
+- 在非 Windows 平台上，系统将回退到 `_rdtsc` 指令或执行时间统计，仍可生成压力分布报告。
+- 若在生产环境部署，请确保程序具备写入 `BPST_PERF_*` 路径的权限。

--- a/benches/dpdp_folding.rs
+++ b/benches/dpdp_folding.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+
+use ark_bn254::Fr;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use num_bigint::BigUint;
+
+use bpst::common::datastructures::{DPDPParams, DPDPProof, DPDPTags};
+use bpst::crypto::dpdp::DPDP;
+use bpst::crypto::folding::{dpdp_verification_relaxed_r1cs, RelaxedR1CS};
+use bpst::monitoring::perf;
+
+#[derive(Clone)]
+struct BenchmarkFixture {
+    params: DPDPParams,
+    chunks: Vec<Vec<u8>>,
+    tags: DPDPTags,
+    chunk_map: HashMap<usize, Vec<u8>>,
+    challenge: Vec<(usize, BigUint)>,
+    proof: DPDPProof,
+    circuit: RelaxedR1CS<Fr>,
+}
+
+fn sample_chunks(count: usize, size: usize) -> Vec<Vec<u8>> {
+    (0..count)
+        .map(|i| {
+            let mut chunk = vec![0u8; size];
+            for (idx, byte) in chunk.iter_mut().enumerate() {
+                *byte = ((i + idx) % 251) as u8;
+            }
+            chunk
+        })
+        .collect()
+}
+
+fn build_fixture(
+    chunk_count: usize,
+    chunk_size: usize,
+    challenge_count: usize,
+) -> BenchmarkFixture {
+    let _guard = perf::monitor().scoped_disable();
+    let params = DPDP::key_gen();
+    let chunks = sample_chunks(chunk_count, chunk_size);
+    let tags = DPDP::tag_file(&params, &chunks);
+    let challenge = DPDP::gen_chal("bench-fixture", 1, &tags, Some(challenge_count));
+    let chunk_map = chunks
+        .iter()
+        .enumerate()
+        .map(|(i, chunk)| (i, chunk.clone()))
+        .collect::<HashMap<_, _>>();
+    let proof = DPDP::gen_proof(&tags, &chunk_map, &challenge);
+    let (circuit, _) = dpdp_verification_relaxed_r1cs(&params, &proof, &challenge);
+    BenchmarkFixture {
+        params,
+        chunks,
+        tags,
+        chunk_map,
+        challenge,
+        proof,
+        circuit,
+    }
+}
+
+fn bench_dpdp(c: &mut Criterion) {
+    let fixture = build_fixture(64, 1024, 16);
+    perf::monitor().clear();
+
+    let mut group = c.benchmark_group("dPDP");
+    let params = fixture.params.clone();
+    let chunks = fixture.chunks.clone();
+    group.bench_function("tag_file", |b| {
+        b.iter(|| {
+            let tags = DPDP::tag_file(black_box(&params), black_box(&chunks));
+            black_box(tags);
+        });
+    });
+
+    let tags_for_proof = fixture.tags.clone();
+    let chunk_map = fixture.chunk_map.clone();
+    let challenge = fixture.challenge.clone();
+    group.bench_function("gen_proof", |b| {
+        b.iter(|| {
+            let proof = DPDP::gen_proof(
+                black_box(&tags_for_proof),
+                black_box(&chunk_map),
+                black_box(&challenge),
+            );
+            black_box(proof);
+        });
+    });
+
+    let params_for_check = fixture.params.clone();
+    let proof_for_check = fixture.proof.clone();
+    group.bench_function("check_proof", |b| {
+        b.iter(|| {
+            let valid = DPDP::check_proof(
+                black_box(&params_for_check),
+                black_box(&proof_for_check),
+                black_box(&challenge),
+            );
+            black_box(valid);
+        });
+    });
+
+    group.finish();
+
+    println!("=== dPDP consensus pressure ===");
+    for (label, share) in perf::monitor().consensus_pressure_report() {
+        println!("  {label}: {share:.2}%");
+    }
+    perf::monitor().clear();
+}
+
+fn bench_folding(c: &mut Criterion) {
+    let fixture = build_fixture(64, 1024, 16);
+    perf::monitor().clear();
+
+    let mut group = c.benchmark_group("Folding");
+    let params = fixture.params.clone();
+    let proof = fixture.proof.clone();
+    let challenge = fixture.challenge.clone();
+    group.bench_function("dpdp_relaxed_r1cs", |b| {
+        b.iter(|| {
+            let result = dpdp_verification_relaxed_r1cs(
+                black_box(&params),
+                black_box(&proof),
+                black_box(&challenge),
+            );
+            black_box(result);
+        });
+    });
+
+    let circuit = fixture.circuit.clone();
+    group.bench_function("relaxed_is_satisfied", |b| {
+        b.iter(|| {
+            let satisfied = circuit.is_satisfied();
+            black_box(satisfied);
+        });
+    });
+
+    group.finish();
+
+    println!("=== Folding consensus pressure ===");
+    for (label, share) in perf::monitor().consensus_pressure_report() {
+        println!("  {label}: {share:.2}%");
+    }
+    perf::monitor().clear();
+}
+
+criterion_group!(benches, bench_dpdp, bench_folding);
+criterion_main!(benches);

--- a/src/monitoring/perf.rs
+++ b/src/monitoring/perf.rs
@@ -1,7 +1,9 @@
 use std::cell::RefCell;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io::{Cursor, Error, ErrorKind};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
@@ -9,6 +11,11 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
 use inferno::flamegraph::{from_reader, Options};
+
+#[cfg(target_os = "windows")]
+use windows::Win32::Foundation::BOOL;
+#[cfg(target_os = "windows")]
+use windows::Win32::System::Threading::{GetCurrentThread, QueryThreadCycleTime};
 
 #[derive(Clone, Default)]
 struct PerfContext {
@@ -38,12 +45,25 @@ fn pop_context() {
 }
 
 fn read_cpu_cycles() -> Option<u64> {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_os = "windows")]
+    {
+        unsafe {
+            let mut cycles: u64 = 0;
+            let handle = GetCurrentThread();
+            let result: BOOL = QueryThreadCycleTime(handle, &mut cycles);
+            if result.as_bool() {
+                Some(cycles)
+            } else {
+                None
+            }
+        }
+    }
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     {
         // Safety: _rdtsc has no safety requirements beyond running on x86/x86_64.
         Some(unsafe { core::arch::x86_64::_rdtsc() })
     }
-    #[cfg(target_arch = "x86")]
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86"))]
     {
         Some(unsafe { core::arch::x86::_rdtsc() })
     }
@@ -69,6 +89,7 @@ pub struct PerformanceMonitor {
 }
 
 static PERFORMANCE_MONITOR: Lazy<PerformanceMonitor> = Lazy::new(PerformanceMonitor::default);
+static MONITOR_ENABLED: AtomicBool = AtomicBool::new(true);
 
 pub fn monitor() -> &'static PerformanceMonitor {
     &PERFORMANCE_MONITOR
@@ -111,7 +132,19 @@ impl PerformanceMonitor {
     }
 
     pub fn record(&self, record: PerfRecord) {
+        if !MONITOR_ENABLED.load(AtomicOrdering::Relaxed) {
+            return;
+        }
         self.records.lock().push(record);
+    }
+
+    pub fn set_enabled(&self, enabled: bool) {
+        MONITOR_ENABLED.store(enabled, AtomicOrdering::SeqCst);
+    }
+
+    pub fn scoped_disable(&'static self) -> PerfDisableGuard {
+        let previous = MONITOR_ENABLED.swap(false, AtomicOrdering::SeqCst);
+        PerfDisableGuard::new(previous)
     }
 
     pub fn export_csv(&self) -> String {
@@ -140,6 +173,52 @@ impl PerformanceMonitor {
             csv.push_str(&row);
         }
         csv
+    }
+
+    pub fn consensus_pressure_report(&self) -> Vec<(String, f64)> {
+        let mut totals: HashMap<String, (u128, u128)> = HashMap::new();
+        let mut total_duration: u128 = 0;
+        let mut total_cycles: u128 = 0;
+        let mut any_cycles = false;
+        for record in self.records.lock().iter() {
+            if record.stack.is_empty() {
+                continue;
+            }
+            let duration = record.duration_ns.max(1);
+            total_duration = total_duration.saturating_add(duration);
+            let cycles = record.cpu_cycles.unwrap_or(0) as u128;
+            if record.cpu_cycles.is_some() {
+                any_cycles = true;
+                total_cycles = total_cycles.saturating_add(cycles);
+            }
+            let root = record
+                .stack
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            let entry = totals.entry(root).or_insert((0, 0));
+            entry.0 = entry.0.saturating_add(duration);
+            if record.cpu_cycles.is_some() {
+                entry.1 = entry.1.saturating_add(cycles);
+            }
+        }
+        let (use_cycles, total_metric) = if any_cycles && total_cycles > 0 {
+            (true, total_cycles)
+        } else if total_duration > 0 {
+            (false, total_duration)
+        } else {
+            return Vec::new();
+        };
+        let mut breakdown: Vec<(String, f64)> = totals
+            .into_iter()
+            .map(|(label, (duration, cycles))| {
+                let metric = if use_cycles { cycles } else { duration };
+                let share = (metric as f64 / total_metric as f64) * 100.0;
+                (label, share)
+            })
+            .collect();
+        breakdown.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+        breakdown
     }
 
     fn collapsed_stacks(&self) -> Vec<(String, u128)> {
@@ -257,6 +336,10 @@ impl PerfSpan {
 
     fn close(&mut self) {
         if self.closed {
+            return;
+        }
+        if !MONITOR_ENABLED.load(AtomicOrdering::Relaxed) {
+            self.closed = true;
             return;
         }
         let duration = self.start_instant.elapsed().as_nanos();
@@ -392,9 +475,27 @@ where
     monitor().start_span_with_context(node_id, user_id, labels)
 }
 
+pub struct PerfDisableGuard {
+    previous: bool,
+}
+
+impl PerfDisableGuard {
+    fn new(previous: bool) -> Self {
+        Self { previous }
+    }
+}
+
+impl Drop for PerfDisableGuard {
+    fn drop(&mut self) {
+        MONITOR_ENABLED.store(self.previous, AtomicOrdering::SeqCst);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::crypto::dpdp::DPDP;
+    use std::collections::HashMap;
 
     #[test]
     fn records_span_duration_and_stack() {
@@ -425,5 +526,68 @@ mod tests {
         }
         let svg = monitor().export_flamegraph_svg().expect("svg output");
         assert!(svg.contains("<svg"));
+    }
+
+    #[test]
+    fn consensus_pressure_reports_root_labels() {
+        monitor().clear();
+        let params = DPDP::key_gen();
+        let chunks: Vec<Vec<u8>> = (0..8).map(|i| vec![i as u8; 128]).collect();
+        let tags = DPDP::tag_file(&params, &chunks);
+        let challenge = DPDP::gen_chal("seed", 42, &tags, Some(4));
+        let mut chunk_map: HashMap<usize, Vec<u8>> = HashMap::new();
+        for (i, chunk) in chunks.iter().enumerate() {
+            chunk_map.insert(i, chunk.clone());
+        }
+        let proof = DPDP::gen_proof(&tags, &chunk_map, &challenge);
+        let _ = DPDP::check_proof_with_relaxed(&params, &proof, &challenge);
+
+        let breakdown = monitor().consensus_pressure_report();
+        assert!(breakdown
+            .iter()
+            .any(|(label, share)| label == "dPDP" && *share > 0.0));
+        assert!(breakdown
+            .iter()
+            .any(|(label, share)| label == "Folding" && *share > 0.0));
+        let total_share: f64 = breakdown.iter().map(|(_, share)| share).sum();
+        assert!(total_share > 0.0);
+        monitor().clear();
+    }
+
+    #[test]
+    fn consensus_pressure_prefers_cpu_cycles_when_available() {
+        monitor().clear();
+        let now = Utc::now();
+        monitor().record(PerfRecord {
+            start_time: now,
+            node_id: None,
+            user_id: None,
+            stack: vec!["alpha".to_string()],
+            duration_ns: 10,
+            cpu_cycles: Some(10),
+        });
+        monitor().record(PerfRecord {
+            start_time: now,
+            node_id: None,
+            user_id: None,
+            stack: vec!["beta".to_string()],
+            duration_ns: 10_000,
+            cpu_cycles: Some(10),
+        });
+
+        let breakdown = monitor().consensus_pressure_report();
+        assert_eq!(breakdown.len(), 2);
+        let alpha_share = breakdown
+            .iter()
+            .find(|(label, _)| label == "alpha")
+            .map(|(_, share)| *share)
+            .unwrap();
+        let beta_share = breakdown
+            .iter()
+            .find(|(label, _)| label == "beta")
+            .map(|(_, share)| *share)
+            .unwrap();
+        assert!((alpha_share - beta_share).abs() < f64::EPSILON);
+        monitor().clear();
     }
 }


### PR DESCRIPTION
## Summary
- prefer CPU cycles when available when computing the consensus pressure breakdown and cover the behaviour with a unit test
- document how to run the project, execute benchmarks, and export monitoring data from the performance monitor

## Testing
- cargo fmt
- cargo test
- cargo bench --no-run

------
https://chatgpt.com/codex/tasks/task_e_68f8b4cd7294832788cb8190514852a6