### PR TITLE
Fix Windows CPU cycle query binding

### DIFF
--- a/src/monitoring/perf.rs
+++ b/src/monitoring/perf.rs
@@ -13,9 +13,15 @@ use parking_lot::Mutex;
 use inferno::flamegraph::{from_reader, Options};
 
 #[cfg(target_os = "windows")]
-use windows::Win32::Foundation::BOOL;
+use windows::Win32::Foundation::{BOOL, HANDLE};
 #[cfg(target_os = "windows")]
-use windows::Win32::System::Threading::{GetCurrentThread, QueryThreadCycleTime};
+use windows::Win32::System::Threading::GetCurrentThread;
+
+#[cfg(target_os = "windows")]
+#[link(name = "kernel32")]
+extern "system" {
+    fn QueryThreadCycleTime(ThreadHandle: HANDLE, CycleTime: *mut u64) -> BOOL;
+}
 
 #[derive(Clone, Default)]
 struct PerfContext {


### PR DESCRIPTION
## Summary
- declare a manual kernel32 binding for `QueryThreadCycleTime` when compiling on Windows
- keep the thread cycle counter functionality working even if the generated windows crate does not expose the symbol

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f8c032d7e88327aebc9b7012f96615