### PR TITLE
Handle empty performance flamegraph exports

### DIFF
--- a/src/monitoring/perf.rs
+++ b/src/monitoring/perf.rs
@@ -274,6 +274,12 @@ impl PerformanceMonitor {
     }
 
     pub fn write_flamegraph_to<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
+        {
+            let records = self.records.lock();
+            if records.is_empty() {
+                return Ok(());
+            }
+        }
         let svg = self.export_flamegraph_svg()?;
         std::fs::write(path, svg)
     }


### PR DESCRIPTION
## Summary
- skip generating flamegraph files when no performance records are available to prevent inferno errors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f8c530b938832790910927a042add7