### PR TITLE
Add consensus runtime metrics and estimates export

### DIFF
--- a/benches/dpdp_folding.rs
+++ b/benches/dpdp_folding.rs
@@ -61,6 +61,40 @@ fn build_fixture(
     }
 }
 
+fn format_duration(ns: u128) -> String {
+    let seconds = ns as f64 / 1_000_000_000.0;
+    if seconds >= 1.0 {
+        format!("{seconds:.3}s")
+    } else {
+        let millis = ns as f64 / 1_000_000.0;
+        if millis >= 1.0 {
+            format!("{millis:.3}ms")
+        } else {
+            let micros = ns as f64 / 1_000.0;
+            format!("{micros:.3}µs")
+        }
+    }
+}
+
+fn print_runtime_report(label: &str) {
+    let total_ns = criterion::monitor().total_duration_ns();
+    println!("=== {label} total runtime ===");
+    println!("  total: {} ({} ns)", format_duration(total_ns), total_ns);
+
+    let stats = criterion::monitor().consensus_operation_stats();
+    if !stats.is_empty() {
+        println!("=== {label} consensus operations ===");
+        for entry in stats {
+            println!(
+                "  {}: {} ({:.2}% of total)",
+                entry.operation,
+                format_duration(entry.total_duration_ns),
+                entry.share_of_total * 100.0
+            );
+        }
+    }
+}
+
 fn bench_dpdp(c: &mut Criterion) {
     let fixture = build_fixture(64, 1024, 16);
     criterion::monitor().clear();
@@ -124,6 +158,8 @@ fn bench_dpdp(c: &mut Criterion) {
     });
 
     group.finish();
+
+    print_runtime_report("dPDP");
 
     println!("=== dPDP consensus pressure ===");
     for (label, share) in criterion::monitor().consensus_pressure_report() {
@@ -229,6 +265,8 @@ fn bench_folding(c: &mut Criterion) {
     });
 
     nova_group.finish();
+
+    print_runtime_report("Folding");
 
     println!("=== Folding consensus pressure ===");
     for (label, share) in criterion::monitor().consensus_pressure_report() {

--- a/src/monitoring/criterion.rs
+++ b/src/monitoring/criterion.rs
@@ -130,6 +130,16 @@ impl CriterionMonitor {
         CriterionSummary::from_records(&records).module_breakdown()
     }
 
+    pub fn total_duration_ns(&self) -> u128 {
+        let records = self.records.lock();
+        CriterionSummary::from_records(&records).total_duration_ns
+    }
+
+    pub fn consensus_operation_stats(&self) -> Vec<ConsensusOperationStat> {
+        let records = self.records.lock();
+        CriterionSummary::from_records(&records).consensus_operation_stats()
+    }
+
     pub fn write_csv_to<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let path = path.as_ref();
         ensure_parent_directory(path)?;
@@ -257,9 +267,17 @@ impl Drop for CriterionContextGuard {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ConsensusOperationStat {
+    pub operation: String,
+    pub total_duration_ns: u128,
+    pub share_of_total: f64,
+}
+
 pub struct CriterionExportGuard {
     csv_path: Option<PathBuf>,
     summary_path: Option<PathBuf>,
+    estimates_output_dir: Option<PathBuf>,
     clear_after: bool,
 }
 
@@ -270,9 +288,13 @@ impl CriterionExportGuard {
         let clear_after = std::env::var("BPST_CRITERION_CLEAR")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(true);
+        let estimates_output_dir = std::env::var("BPST_CRITERION_ESTIMATES_DIR")
+            .ok()
+            .map(PathBuf::from);
         Self {
             csv_path,
             summary_path,
+            estimates_output_dir,
             clear_after,
         }
     }
@@ -280,11 +302,13 @@ impl CriterionExportGuard {
     pub fn new(
         csv_path: Option<PathBuf>,
         summary_path: Option<PathBuf>,
+        estimates_output_dir: Option<PathBuf>,
         clear_after: bool,
     ) -> Self {
         Self {
             csv_path,
             summary_path,
+            estimates_output_dir,
             clear_after,
         }
     }
@@ -302,6 +326,15 @@ impl Drop for CriterionExportGuard {
                 eprintln!(
                     "failed to write criterion summary {}: {}",
                     path.display(),
+                    err
+                );
+            }
+        }
+        if let Some(dir) = &self.estimates_output_dir {
+            if let Err(err) = copy_estimate_reports(dir) {
+                eprintln!(
+                    "failed to copy criterion estimate reports to {}: {}",
+                    dir.display(),
                     err
                 );
             }
@@ -529,6 +562,27 @@ impl CriterionSummary {
         breakdown.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         breakdown
     }
+
+    fn consensus_operation_stats(&self) -> Vec<ConsensusOperationStat> {
+        let mut totals: BTreeMap<String, u128> = BTreeMap::new();
+        for row in &self.rows {
+            if row.module == "CONSENSUS" {
+                *totals.entry(row.operation.clone()).or_insert(0) += row.total_duration_ns;
+            }
+        }
+
+        let denominator = self.total_duration_ns.max(1) as f64;
+        let mut stats: Vec<ConsensusOperationStat> = totals
+            .into_iter()
+            .map(|(operation, total_duration_ns)| ConsensusOperationStat {
+                operation,
+                total_duration_ns,
+                share_of_total: total_duration_ns as f64 / denominator,
+            })
+            .collect();
+        stats.sort_by(|a, b| b.total_duration_ns.cmp(&a.total_duration_ns));
+        stats
+    }
 }
 
 fn ensure_parent_directory(path: &Path) -> io::Result<()> {
@@ -537,6 +591,47 @@ fn ensure_parent_directory(path: &Path) -> io::Result<()> {
             fs::create_dir_all(parent)?;
         }
     }
+    Ok(())
+}
+
+fn copy_estimate_reports(dest_root: &Path) -> io::Result<()> {
+    let source_root = Path::new("target/criterion");
+    if !source_root.exists() {
+        return Ok(());
+    }
+
+    for group_entry in fs::read_dir(source_root)? {
+        let group_entry = group_entry?;
+        let group_path = group_entry.path();
+        if !group_path.is_dir() {
+            continue;
+        }
+        let Some(group_name) = group_path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+
+        for func_entry in fs::read_dir(&group_path)? {
+            let func_entry = func_entry?;
+            let func_path = func_entry.path();
+            if !func_path.is_dir() {
+                continue;
+            }
+
+            let Some(func_name) = func_path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let source_estimates = func_path.join("new").join("estimates.json");
+            if !source_estimates.exists() {
+                continue;
+            }
+
+            let dest_dir = dest_root.join(group_name);
+            fs::create_dir_all(&dest_dir)?;
+            let dest_file = dest_dir.join(format!("{}.json", func_name));
+            fs::copy(&source_estimates, &dest_file)?;
+        }
+    }
+
     Ok(())
 }
 

--- a/src/p2p/node.rs
+++ b/src/p2p/node.rs
@@ -1168,22 +1168,26 @@ impl Node {
         match thread::Builder::new()
             .name(format!("mining-{}-{}", node_id, height))
             .spawn(move || {
+                let _ctx = criterion::enter_context(Some(node_id.clone()), None::<String>);
                 let mut next_start = 0u64;
                 let mut best_seen: Option<BigUint> = None;
                 while !thread_flag.load(Ordering::SeqCst) {
                     if mining_window == 0 || next_start == u64::MAX {
                         break;
                     }
-                    let proof_opt = with_cpu_heavy_limit(|| {
-                        miner.mine_window(
-                            &seed,
-                            &storage_root,
-                            &file_roots,
-                            num_files,
-                            next_start,
-                            mining_window,
-                        )
-                    });
+                    let proof_opt = {
+                        let _span = criterion::span(["CONSENSUS", "mining"]);
+                        with_cpu_heavy_limit(|| {
+                            miner.mine_window(
+                                &seed,
+                                &storage_root,
+                                &file_roots,
+                                num_files,
+                                next_start,
+                                mining_window,
+                            )
+                        })
+                    };
                     if thread_flag.load(Ordering::SeqCst) {
                         break;
                     }
@@ -1259,6 +1263,8 @@ impl Node {
 
     /// 检查某个高度的证明池是否满足共识条件
     fn evaluate_consensus_for_height(&mut self, height: usize) {
+        let _ctx = criterion::enter_context(Some(self.node_id.clone()), None::<String>);
+        let _span = criterion::span(["CONSENSUS", "threshold_judgement"]);
         if self.election_concluded_for.contains(&height) {
             return;
         }
@@ -1347,7 +1353,7 @@ impl Node {
     /// 创建新区块（仅由领导者调用）
     fn create_block(&mut self, height: usize, winning_proofs: Vec<BobtailProof>) {
         let _ctx = criterion::enter_context(Some(self.node_id.clone()), None::<String>);
-        let _span = criterion::span(["CONSENSUS", "create_block"]);
+        let _span = criterion::span(["CONSENSUS", "block_production"]);
         log_msg(
             "SUCCESS",
             "CONSENSUS",
@@ -1641,6 +1647,8 @@ impl Node {
         current_work: &BigUint,
         candidate_work: &BigUint,
     ) {
+        let _ctx = criterion::enter_context(Some(self.node_id.clone()), None::<String>);
+        let _span = criterion::span(["CONSENSUS", "fork_handling"]);
         let is_reorg = prefix_len < previous_height;
 
         self.stop_mining_thread();


### PR DESCRIPTION
## Summary
- add runtime and consensus operation reporting to the benchmarks
- extend the criterion monitor with total runtime, consensus operation stats, and exporting estimates.json files
- instrument consensus-related paths for mining, fork handling, block production, and threshold judgment spans

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f9a0f477048327b32b6a1e98ff24a6