### PR TITLE
Add run metrics collection and export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "sysinfo",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -847,7 +848,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.0",
 ]
 
 [[package]]
@@ -1079,6 +1080,15 @@ dependencies = [
  "sha3",
  "subtle",
  "thiserror 2.0.16",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1508,6 +1518,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,12 +1727,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bincode = "1.3"
 ff = "0.13"
 ctrlc = "3.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "time"] }
+sysinfo = "0.30"
 
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 use bpst::config::{DeploymentConfig, P2PSimConfig};
 // 初始化日志系统
 use bpst::monitoring::criterion::CriterionExportGuard;
+use bpst::monitoring::run_metrics::RunMetricsExportGuard;
 use bpst::utils::init_logging;
 // 引入 bpst 项目中的 simulation 模块，包含运行节点、用户进程和P2P模拟的功能
 use bpst::simulation::{
@@ -12,6 +13,7 @@ use log::error;
 // Rust 程序的主入口函数
 fn main() {
     let _criterion_export_guard = CriterionExportGuard::from_env();
+    let _run_metrics_guard = RunMetricsExportGuard::from_env();
     // 初始化日志系统，确保控制台输出同时写入日志文件
     init_logging();
     // 获取命令行参数的迭代器

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -1,1 +1,2 @@
 pub mod criterion;
+pub mod run_metrics;

--- a/src/monitoring/run_metrics.rs
+++ b/src/monitoring/run_metrics.rs
@@ -1,0 +1,394 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+use chrono::{SecondsFormat, Utc};
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use sysinfo::{get_current_pid, System};
+
+#[derive(Clone, Default)]
+struct RunMetric {
+    timestamp: chrono::DateTime<Utc>,
+    category: String,
+    metric: String,
+    value: f64,
+    raw_value: String,
+    unit: String,
+    extra: BTreeMap<String, String>,
+}
+
+impl RunMetric {
+    fn to_csv_row(&self) -> String {
+        let timestamp = self.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true);
+        let extra_json = serde_json::to_string(&self.extra).unwrap_or_else(|_| "{}".into());
+        format!(
+            "{},{},{},{:.6},{},{},{}\n",
+            timestamp,
+            self.category,
+            self.metric,
+            self.value,
+            self.raw_value,
+            self.unit,
+            extra_json
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct RunMetricsCollector {
+    metrics: Mutex<Vec<RunMetric>>,
+}
+
+static RUN_METRICS: Lazy<RunMetricsCollector> = Lazy::new(RunMetricsCollector::default);
+
+pub fn metrics() -> &'static RunMetricsCollector {
+    &RUN_METRICS
+}
+
+impl RunMetricsCollector {
+    fn record(&self, metric: RunMetric) {
+        self.metrics.lock().push(metric);
+    }
+
+    fn record_numeric_metric<S1, S2, S3>(
+        &self,
+        category: S1,
+        metric: S2,
+        value: f64,
+        raw_value: String,
+        unit: S3,
+        extra: BTreeMap<String, String>,
+    ) where
+        S1: Into<String>,
+        S2: Into<String>,
+        S3: Into<String>,
+    {
+        self.record(RunMetric {
+            timestamp: Utc::now(),
+            category: category.into(),
+            metric: metric.into(),
+            value,
+            raw_value,
+            unit: unit.into(),
+            extra,
+        });
+    }
+
+    pub fn record_block_size(&self, node_id: &str, height: u64, size_bytes: usize) {
+        let mut extra = BTreeMap::new();
+        extra.insert("node_id".into(), node_id.to_string());
+        extra.insert("height".into(), height.to_string());
+        self.record_numeric_metric(
+            "consensus",
+            "block_size_bytes",
+            size_bytes as f64,
+            size_bytes.to_string(),
+            "B",
+            extra,
+        );
+    }
+
+    pub fn record_folding_round_time(
+        &self,
+        node_id: &str,
+        file_id: &str,
+        block_height: u64,
+        round: usize,
+        circuit_count: usize,
+        duration_ns: u128,
+    ) {
+        let mut extra = BTreeMap::new();
+        extra.insert("node_id".into(), node_id.to_string());
+        extra.insert("file_id".into(), file_id.to_string());
+        extra.insert("block_height".into(), block_height.to_string());
+        extra.insert("round".into(), round.to_string());
+        extra.insert("circuit_count".into(), circuit_count.to_string());
+        self.record_numeric_metric(
+            "folding",
+            "round_duration_ns",
+            duration_ns as f64,
+            duration_ns.to_string(),
+            "ns",
+            extra,
+        );
+    }
+
+    pub fn record_folding_proof_size(
+        &self,
+        node_id: &str,
+        file_id: &str,
+        block_height: u64,
+        round: usize,
+        proof_bytes: usize,
+    ) {
+        let mut extra = BTreeMap::new();
+        extra.insert("node_id".into(), node_id.to_string());
+        extra.insert("file_id".into(), file_id.to_string());
+        extra.insert("block_height".into(), block_height.to_string());
+        extra.insert("round".into(), round.to_string());
+        self.record_numeric_metric(
+            "folding",
+            "round_proof_size_bytes",
+            proof_bytes as f64,
+            proof_bytes.to_string(),
+            "B",
+            extra,
+        );
+    }
+
+    pub fn record_dpdp_proof_latency(
+        &self,
+        node_id: &str,
+        file_id: &str,
+        challenge_len: usize,
+        duration_ns: u128,
+    ) {
+        let mut extra = BTreeMap::new();
+        extra.insert("node_id".into(), node_id.to_string());
+        extra.insert("file_id".into(), file_id.to_string());
+        extra.insert("challenge_len".into(), challenge_len.to_string());
+        self.record_numeric_metric(
+            "dpdp",
+            "proof_latency_ns",
+            duration_ns as f64,
+            duration_ns.to_string(),
+            "ns",
+            extra,
+        );
+    }
+
+    pub fn record_dpdp_proof_size(
+        &self,
+        node_id: &str,
+        file_id: &str,
+        block_height: Option<u64>,
+        round: Option<usize>,
+        proof_bytes: usize,
+    ) {
+        let mut extra = BTreeMap::new();
+        extra.insert("node_id".into(), node_id.to_string());
+        extra.insert("file_id".into(), file_id.to_string());
+        if let Some(height) = block_height {
+            extra.insert("block_height".into(), height.to_string());
+        }
+        if let Some(round) = round {
+            extra.insert("round".into(), round.to_string());
+        }
+        self.record_numeric_metric(
+            "dpdp",
+            "proof_size_bytes",
+            proof_bytes as f64,
+            proof_bytes.to_string(),
+            "B",
+            extra,
+        );
+    }
+
+    pub fn record_dpdp_tag_throughput(
+        &self,
+        owner_id: &str,
+        file_id: &str,
+        total_bytes: usize,
+        duration_ns: u128,
+    ) {
+        let mut extra = BTreeMap::new();
+        extra.insert("owner_id".into(), owner_id.to_string());
+        extra.insert("file_id".into(), file_id.to_string());
+        extra.insert("total_bytes".into(), total_bytes.to_string());
+        extra.insert("duration_ns".into(), duration_ns.to_string());
+        let duration_secs = (duration_ns as f64) / 1_000_000_000.0;
+        let throughput = if duration_secs > f64::EPSILON {
+            total_bytes as f64 / duration_secs
+        } else {
+            total_bytes as f64
+        };
+        self.record_numeric_metric(
+            "dpdp",
+            "tag_throughput_Bps",
+            throughput,
+            format!("{throughput:.3}"),
+            "B/s",
+            extra,
+        );
+    }
+
+    pub fn record_final_folding_proof_artifact(
+        &self,
+        file_id: &str,
+        steps: usize,
+        proof_bytes: usize,
+        vk_bytes: usize,
+        prove_ns: u128,
+    ) {
+        let mut common = BTreeMap::new();
+        common.insert("file_id".into(), file_id.to_string());
+        common.insert("steps".into(), steps.to_string());
+        self.record_numeric_metric(
+            "folding",
+            "final_proof_size_bytes",
+            proof_bytes as f64,
+            proof_bytes.to_string(),
+            "B",
+            common.clone(),
+        );
+        self.record_numeric_metric(
+            "folding",
+            "final_verifier_key_size_bytes",
+            vk_bytes as f64,
+            vk_bytes.to_string(),
+            "B",
+            common.clone(),
+        );
+        self.record_numeric_metric(
+            "folding",
+            "final_prove_latency_ns",
+            prove_ns as f64,
+            prove_ns.to_string(),
+            "ns",
+            common.clone(),
+        );
+    }
+
+    pub fn record_final_folding_verify_latency(
+        &self,
+        file_id: &str,
+        steps: usize,
+        verify_ns: u128,
+    ) {
+        let mut extra = BTreeMap::new();
+        extra.insert("file_id".into(), file_id.to_string());
+        extra.insert("steps".into(), steps.to_string());
+        self.record_numeric_metric(
+            "folding",
+            "final_verify_latency_ns",
+            verify_ns as f64,
+            verify_ns.to_string(),
+            "ns",
+            extra,
+        );
+    }
+
+    pub fn record_cpu_snapshot(&self) {
+        let mut system = System::new_all();
+        system.refresh_cpu();
+        system.refresh_memory();
+        let pid = get_current_pid().ok();
+        if let Some(pid) = pid {
+            system.refresh_process(pid);
+        }
+        thread::sleep(Duration::from_millis(200));
+        system.refresh_cpu();
+        system.refresh_memory();
+        if let Some(pid) = pid {
+            system.refresh_process(pid);
+        }
+
+        let cpu = system.global_cpu_info().cpu_usage();
+        let total_memory = system.total_memory() * 1024;
+        let used_memory = system.used_memory() * 1024;
+        let mut system_extra = BTreeMap::new();
+        system_extra.insert("scope".into(), "system".into());
+        system_extra.insert("total_memory_bytes".into(), total_memory.to_string());
+        system_extra.insert("used_memory_bytes".into(), used_memory.to_string());
+        self.record_numeric_metric(
+            "system",
+            "cpu_usage_percent",
+            cpu as f64,
+            format!("{cpu:.3}"),
+            "%",
+            system_extra,
+        );
+
+        if let Some(pid) = pid {
+            if let Some(process) = system.process(pid) {
+                let mut cpu_extra = BTreeMap::new();
+                cpu_extra.insert("pid".into(), pid.as_u32().to_string());
+                self.record_numeric_metric(
+                    "process",
+                    "cpu_usage_percent",
+                    process.cpu_usage() as f64,
+                    format!("{:.3}", process.cpu_usage()),
+                    "%",
+                    cpu_extra.clone(),
+                );
+
+                let mut mem_extra = BTreeMap::new();
+                mem_extra.insert("pid".into(), pid.as_u32().to_string());
+                self.record_numeric_metric(
+                    "process",
+                    "memory_usage_bytes",
+                    (process.memory() * 1024) as f64,
+                    (process.memory() * 1024).to_string(),
+                    "B",
+                    mem_extra,
+                );
+            }
+        }
+    }
+
+    pub fn export_csv(&self) -> String {
+        let mut out = String::from("timestamp,category,metric,value,value_raw,unit,extra\n");
+        for metric in self.metrics.lock().iter() {
+            out.push_str(&metric.to_csv_row());
+        }
+        out
+    }
+
+    pub fn write_csv_to<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        fs::write(path, self.export_csv())
+    }
+}
+
+pub struct RunMetricsExportGuard {
+    csv_path: Option<PathBuf>,
+    record_cpu: bool,
+}
+
+impl RunMetricsExportGuard {
+    pub fn from_env() -> Self {
+        let csv_path = std::env::var("BPST_RUN_METRICS_CSV")
+            .ok()
+            .map(PathBuf::from);
+        let record_cpu = std::env::var("BPST_RUN_METRICS_CPU")
+            .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
+            .unwrap_or(true);
+        Self {
+            csv_path,
+            record_cpu,
+        }
+    }
+
+    pub fn new(csv_path: Option<PathBuf>, record_cpu: bool) -> Self {
+        Self {
+            csv_path,
+            record_cpu,
+        }
+    }
+}
+
+impl Drop for RunMetricsExportGuard {
+    fn drop(&mut self) {
+        if self.record_cpu {
+            metrics().record_cpu_snapshot();
+        }
+        if let Some(path) = &self.csv_path {
+            if let Err(err) = metrics().write_csv_to(path) {
+                eprintln!(
+                    "failed to write run metrics CSV {}: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
+    }
+}

--- a/src/p2p/node.rs
+++ b/src/p2p/node.rs
@@ -29,7 +29,7 @@ use crate::common::datastructures::{
 use crate::consensus::blockchain::Blockchain; // 区块链逻辑
 use crate::crypto::deserialize_g2; // G2点反序列化工具
 use crate::crypto::dpdp::DPDP; // dPDP 密码学逻辑
-use crate::monitoring::criterion;
+use crate::monitoring::{criterion, run_metrics};
 use crate::roles::miner::Miner; // 矿工角色
 use crate::roles::prover::Prover; // 证明者角色
 use crate::storage::manager::{FileDataError, StorageManager}; // 存储管理器
@@ -1564,6 +1564,13 @@ impl Node {
 
         // 领导者首先更新自己的链，避免等待gossip反馈
         let gossip_block = new_block.clone();
+        if let Ok(serialized) = bincode::serialize(&new_block) {
+            run_metrics::metrics().record_block_size(
+                &self.node_id,
+                new_block.height,
+                serialized.len(),
+            );
+        }
         if !matches!(self.accept_block(new_block), BlockHandlingResult::Accepted) {
             log_msg(
                 "ERROR",

--- a/src/p2p/user_node.rs
+++ b/src/p2p/user_node.rs
@@ -5,7 +5,7 @@ use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use rand::seq::SliceRandom;
 use rand::Rng;
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::common::datastructures::FileChunk;
 use crate::config::P2PSimConfig;
 use crate::crypto::{folding::NovaFoldingCycle, serialize_g2};
-use crate::monitoring::criterion;
+use crate::monitoring::{criterion, run_metrics};
 use crate::roles::file_owner::FileOwner;
 use crate::utils::{log_msg, with_cpu_heavy_limit};
 
@@ -537,8 +537,17 @@ impl UserNode {
             Err(_) => return Err(String::from("无法解析最终证明或验证密钥")),
         };
 
-        match NovaFoldingCycle::verify_final_accumulator(args.steps, &compressed_bytes, &vk_bytes) {
+        let verify_start = Instant::now();
+        let verification =
+            NovaFoldingCycle::verify_final_accumulator(args.steps, &compressed_bytes, &vk_bytes);
+        let verify_elapsed = verify_start.elapsed().as_nanos();
+        match verification {
             Ok(proof_acc) => {
+                run_metrics::metrics().record_final_folding_verify_latency(
+                    args.file_id,
+                    args.steps,
+                    verify_elapsed,
+                );
                 if proof_acc == args.accumulator && args.steps == record.required_rounds {
                     if !already_verified {
                         log_msg(

--- a/src/roles/file_owner.rs
+++ b/src/roles/file_owner.rs
@@ -1,10 +1,11 @@
 // 导入随机数生成器相关的 trait
 use rand::{Rng, RngCore};
+use std::time::Instant;
 
 // 导入项目内的数据结构和密码学模块
 use crate::common::datastructures::{DPDPParams, DPDPTags, FileChunk};
 use crate::crypto::dpdp::DPDP;
-use crate::monitoring::criterion;
+use crate::monitoring::{criterion, run_metrics};
 use crate::utils::log_msg;
 
 /// FileOwner 结构体定义了文件所有者的角色
@@ -75,7 +76,18 @@ impl FileOwner {
         // 1. 将文件字节流分割成原始数据块
         let raw_chunks = self.split_file(file_bytes);
         // 2. 使用 dPDP 私钥为所有数据块生成对应的标签
+        let total_bytes: usize = raw_chunks.iter().map(|chunk| chunk.len()).sum();
+        let start = Instant::now();
         let tags = DPDP::tag_file(&self.params, &raw_chunks);
+        let elapsed = start.elapsed().as_nanos();
+        if total_bytes > 0 {
+            run_metrics::metrics().record_dpdp_tag_throughput(
+                &self.owner_id,
+                &self.file_id,
+                total_bytes,
+                elapsed,
+            );
+        }
         // 3. 将原始数据块和生成的标签打包成 FileChunk 结构体
         let chunks: Vec<FileChunk> = raw_chunks
             .into_iter()

--- a/src/roles/prover.rs
+++ b/src/roles/prover.rs
@@ -7,8 +7,9 @@ use num_bigint::BigUint;
 // 导入项目内的数据结构和密码学模块
 use crate::common::datastructures::{DPDPProof, DPDPTags};
 use crate::crypto::dpdp::DPDP;
-use crate::monitoring::criterion;
+use crate::monitoring::{criterion, run_metrics};
 use crate::utils::log_msg;
+use std::time::Instant;
 
 /// dPDP 挑战向量类型别名，元素为 (块索引, 挑战系数)。
 pub type ChallengeVector = Vec<(usize, BigUint)>;
@@ -60,7 +61,24 @@ impl Prover {
         let challenge = DPDP::gen_chal(prev_hash, timestamp, file_tags, challenge_size);
 
         // 2. 使用文件块、标签和挑战来生成聚合的 dPDP 证明
+        let prove_start = Instant::now();
         let proof = DPDP::gen_proof(file_tags, file_chunks, &challenge);
+        let prove_elapsed = prove_start.elapsed().as_nanos();
+        run_metrics::metrics().record_dpdp_proof_latency(
+            &self.node_id,
+            file_id,
+            challenge.len(),
+            prove_elapsed,
+        );
+        if let Ok(serialized) = bincode::serialize(&proof) {
+            run_metrics::metrics().record_dpdp_proof_size(
+                &self.node_id,
+                file_id,
+                None,
+                None,
+                serialized.len(),
+            );
+        }
 
         // 3. 生成用于更新文件状态的“贡献值”
         // 这些值是证明过程的副产品，但对于维护文件的版本和状态至关重要

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::net::SocketAddr;
+use std::time::Instant;
 
 use ark_bn254::{Fr, G1Projective, G2Projective};
 use ark_ec::PrimeGroup;
@@ -13,7 +14,7 @@ use crate::crypto::folding::{
     state_update_relaxed_r1cs, NovaFinalProof, NovaFoldingCycle, NovaFoldingError, NovaRoundResult,
     RelaxedR1CS,
 };
-use crate::monitoring::criterion;
+use crate::monitoring::{criterion, run_metrics};
 use crate::storage::state::ServerStorage;
 use crate::utils::{h_join, sha256_hex};
 use serde_json::Value as JsonValue;
@@ -718,6 +719,7 @@ impl StorageManager {
                 &format!("准备吸收文件 {} 的第 {} 个折叠轮次。", file_id, next_step),
             );
             let circuits = vec![dpdp_circuit, block_circuit, state_circuit];
+            let fold_start = Instant::now();
             let result = match cycle.nova.absorb_round(circuits.clone()) {
                 Ok(res) => res,
                 Err(NovaFoldingError::CycleComplete) => return None,
@@ -731,6 +733,15 @@ impl StorageManager {
                     return None;
                 }
             };
+            let fold_duration = fold_start.elapsed().as_nanos();
+            run_metrics::metrics().record_folding_round_time(
+                &self.node_id,
+                file_id,
+                block_height,
+                result.step_index,
+                circuits.len(),
+                fold_duration,
+            );
             crate::utils::log_msg(
                 "INFO",
                 "Nova",
@@ -751,6 +762,22 @@ impl StorageManager {
                 circuits,
                 history_leaf_updates,
             );
+            if let Ok(serialized_proof) = bincode::serialize(proof) {
+                run_metrics::metrics().record_folding_proof_size(
+                    &self.node_id,
+                    file_id,
+                    block_height,
+                    result.step_index,
+                    serialized_proof.len(),
+                );
+                run_metrics::metrics().record_dpdp_proof_size(
+                    &self.node_id,
+                    file_id,
+                    Some(block_height),
+                    Some(result.step_index),
+                    serialized_proof.len(),
+                );
+            }
 
             if result.step_index >= cycle.storage_period && cycle.final_artifact.is_none() {
                 crate::utils::log_msg(
@@ -759,8 +786,22 @@ impl StorageManager {
                     Some(self.node_id.clone()),
                     &format!("文件 {} 达到存储周期阈值，尝试生成最终折叠证明。", file_id),
                 );
+                let finalize_start = Instant::now();
                 match cycle.nova.finalize() {
-                    Ok(Some(final_proof)) => cycle.set_final_artifact(final_proof),
+                    Ok(Some(final_proof)) => {
+                        let finalize_duration = finalize_start.elapsed().as_nanos();
+                        let proof_size = final_proof.compressed_snark.len();
+                        let vk_size = final_proof.verifier_key.len();
+                        let steps = final_proof.steps;
+                        run_metrics::metrics().record_final_folding_proof_artifact(
+                            file_id,
+                            steps,
+                            proof_size,
+                            vk_size,
+                            finalize_duration,
+                        );
+                        cycle.set_final_artifact(final_proof)
+                    }
                     Ok(None) | Err(NovaFoldingError::CycleComplete) => {}
                     Err(err) => {
                         crate::utils::log_msg(


### PR DESCRIPTION
## Summary
- add a run metrics collector with CSV export and optional CPU snapshotting
- instrument block production, folding, dPDP tagging/proving, and final proof verification to record detailed metrics
- wire the collector into the binary via a guard configured through environment variables

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68fb70967b848327917f63a4cb03dd77