### PR TITLE
Refine dPDP and Nova logging

### DIFF
--- a/src/p2p/node.rs
+++ b/src/p2p/node.rs
@@ -687,12 +687,6 @@ impl Node {
             return;
         }
         let Some(owner_addr) = self.storage_manager.get_file_owner_contact(file_id) else {
-            log_msg(
-                "WARN",
-                "STORE",
-                Some(self.node_id.clone()),
-                &format!("无法请求补发文件 {} 的缺失块：未记录所有者地址。", file_id),
-            );
             return;
         };
         let payload = serde_json::json!({
@@ -704,27 +698,7 @@ impl Node {
                 "provider_addr": [self.host.clone(), self.port],
             }
         });
-        if send_json_line(owner_addr, &payload).is_some() {
-            log_msg(
-                "INFO",
-                "STORE",
-                Some(self.node_id.clone()),
-                &format!(
-                    "已向文件 {} 的所有者请求补发缺失块：{:?}",
-                    file_id, missing_indices
-                ),
-            );
-        } else {
-            log_msg(
-                "WARN",
-                "STORE",
-                Some(self.node_id.clone()),
-                &format!(
-                    "请求文件 {} 缺失块失败，无法联系所有者 {}。",
-                    file_id, owner_addr
-                ),
-            );
-        }
+        let _ = send_json_line(owner_addr, &payload);
     }
 
     fn handle_query_final_proof(&self, data: &Value) -> CommandResponse {
@@ -1397,6 +1371,9 @@ impl Node {
 
         // 验证所有获胜者提交的dPDP证明
         let chunk_size = self.storage_manager.chunk_size();
+        let mut dpdp_verified_rounds = 0usize;
+        let mut dpdp_total_chunks = 0usize;
+        let mut dpdp_total_bytes = 0usize;
         for nid in &winners_ids {
             if let Some(update) = updates_for_prev.get(nid) {
                 for (fid, pkg_val) in &update.dpdp_proofs {
@@ -1537,11 +1514,24 @@ impl Node {
                                     nid, fid, challenge_chunks, challenge_bytes
                                 ),
                             );
+                            dpdp_verified_rounds = dpdp_verified_rounds.saturating_add(1);
+                            dpdp_total_chunks = dpdp_total_chunks.saturating_add(challenge_chunks);
+                            dpdp_total_bytes = dpdp_total_bytes.saturating_add(challenge_bytes);
                         }
                     }
                 }
             }
         }
+
+        log_msg(
+            "INFO",
+            "CONSENSUS",
+            Some(self.node_id.clone()),
+            &format!(
+                "高度 {} dPDP 证明验证完成：挑战轮次 {} 次，挑战块数 {}，挑战数据量 {} 字节。",
+                height, dpdp_verified_rounds, dpdp_total_chunks, dpdp_total_bytes
+            ),
+        );
 
         // 构造区块体
         let body = BlockBody {
@@ -1856,15 +1846,6 @@ impl Node {
             let (chunks, tags) = match self.storage_manager.get_file_data_for_proof(fid) {
                 Ok(data) => data,
                 Err(FileDataError::Incomplete { missing_indices }) => {
-                    log_msg(
-                        "WARN",
-                        "dPDP_PROVE",
-                        Some(self.node_id.clone()),
-                        &format!(
-                            "文件 {} 数据缺失，跳过证明并请求补发缺失块 {:?}。",
-                            fid, missing_indices
-                        ),
-                    );
                     self.request_missing_chunks(fid, &missing_indices);
                     continue;
                 }

--- a/src/p2p/user_node.rs
+++ b/src/p2p/user_node.rs
@@ -549,6 +549,17 @@ impl UserNode {
                     verify_elapsed,
                 );
                 if proof_acc == args.accumulator && args.steps == record.required_rounds {
+                    log_msg(
+                        "INFO",
+                        "Nova",
+                        Some(args.owner_id.to_string()),
+                        &format!(
+                            "文件 {} 的最终 Nova 证明验证完成：总折叠轮次 {}，证明大小 {} 字节。",
+                            args.file_id,
+                            args.steps,
+                            compressed_bytes.len()
+                        ),
+                    );
                     if !already_verified {
                         log_msg(
                             "INFO",

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -149,7 +149,11 @@ impl FileCycleState {
         self.final_artifact.is_some()
     }
 
-    fn rollback_to_height(&mut self, target_height: u64) -> (Vec<LeafUpdateRecord>, bool) {
+    fn rollback_to_height(
+        &mut self,
+        file_id: &str,
+        target_height: u64,
+    ) -> (Vec<LeafUpdateRecord>, bool) {
         let to_remove: Vec<u64> = self
             .round_history
             .keys()
@@ -187,7 +191,7 @@ impl FileCycleState {
                         "ERROR",
                         "Nova",
                         None,
-                        &format!("回滚后重建 Nova 折叠状态失败: {}", err),
+                        &format!("回滚文件 {} 的 Nova 折叠状态失败: {}", file_id, err),
                     );
                     break;
                 }
@@ -566,7 +570,7 @@ impl StorageManager {
             let mut changed = false;
             if let Some(cycle) = inner.file_cycles.get_mut(&file_id) {
                 let before_steps = cycle.nova.steps_completed();
-                let (updates, did_change) = cycle.rollback_to_height(target_height);
+                let (updates, did_change) = cycle.rollback_to_height(&file_id, target_height);
                 let after_steps = cycle.nova.steps_completed();
                 if did_change {
                     updates_to_apply = updates;


### PR DESCRIPTION
## Summary
- stop emitting logs when requesting missing chunks during dPDP processing
- add a per-block dPDP verification summary covering challenge counts and data volume
- log Nova final proof verification details, including steps and proof size, and tag rollback errors with the affected file

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68fc7a84cbec8327a88a4c797af93c43