### PR TITLE
Align Nova expected challenge with dPDP generator

### DIFF
--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -657,10 +657,21 @@ impl StorageManager {
             return None;
         }
         let pk_bytes = inner.file_pk_beta.get(file_id)?.clone();
-        let expected_challenge = match inner.file_cycles.get(file_id) {
-            Some(cycle) => cycle.challenge_size,
+        let cycle = match inner.file_cycles.get(file_id) {
+            Some(cycle) => cycle,
             None => return None,
         };
+        let total_chunks = inner
+            .file_expected_chunks
+            .get(file_id)
+            .copied()
+            .or_else(|| inner.files.get(file_id).map(|chunks| chunks.len()))
+            .unwrap_or_default();
+        if total_chunks == 0 {
+            return None;
+        }
+        let required = (total_chunks.saturating_mul(3) + 9) / 10;
+        let expected_challenge = required.max(cycle.challenge_size).min(total_chunks);
         let round_chunks = challenge.len();
         let round_bytes = round_chunks.saturating_mul(inner.chunk_size);
         if round_chunks != expected_challenge {


### PR DESCRIPTION
## Summary
- derive the Nova manager's expected challenge size from the total file chunks
- mirror the dPDP challenge minimum calculation so the fold round accepts valid vectors

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68fc86578de88327bcd016db4a93a2a1